### PR TITLE
feat(governance-store): cache sibling certificates by the account a device speaks for

### DIFF
--- a/crates/governance-store/src/device_link.rs
+++ b/crates/governance-store/src/device_link.rs
@@ -27,6 +27,27 @@ enum BindPlan {
     Skip(BindOutcome),
 }
 
+/// Does this node know `cert`'s device belongs in `namespace`?
+///
+/// Only the holder stores scopes, so a paired device cannot answer for any
+/// sibling and binds none.
+fn in_scope_here(
+    store: &Store,
+    devices: &NodeDeviceRepository<'_>,
+    namespace: &ContextGroupId,
+    cert: &KnownDeviceCert,
+) -> EyreResult<bool> {
+    if !devices.is_account_holder()? {
+        return Ok(false);
+    }
+    // A namespace whose metadata has not synced names no application, and is
+    // reachable only by a scope that names none either.
+    let application = MetaRepository::new(store)
+        .load(namespace)?
+        .map(|meta| meta.target.application_id);
+    Ok(cert.covers(application))
+}
+
 /// Everything that decides whether the pair of publishes is worth making,
 /// cheapest question first.
 fn plan(store: &Store, namespace: &ContextGroupId, cert: &KnownDeviceCert) -> EyreResult<BindPlan> {
@@ -36,13 +57,7 @@ fn plan(store: &Store, namespace: &ContextGroupId, cert: &KnownDeviceCert) -> Ey
     if devices.get()?.is_some_and(|held| held.device() == device) {
         return Ok(BindPlan::Skip(BindOutcome::OwnDevice));
     }
-    // The namespace's target application, read the way the pairing fan-out reads
-    // it. A namespace whose metadata has not synced names none, and is reachable
-    // only by a scope that names none either.
-    let application = MetaRepository::new(store)
-        .load(namespace)?
-        .map(|meta| meta.target.application_id);
-    if !cert.covers(application) {
+    if !in_scope_here(store, &devices, namespace, cert)? {
         return Ok(BindPlan::Skip(BindOutcome::OutOfScope));
     }
 
@@ -362,6 +377,31 @@ mod tests {
             },
             BindPlan::Skip(outcome) => outcome,
         }
+    }
+
+    /// A node whose device was adopted under another account's root: a paired
+    /// phone. Its own root is present, as `merod init` leaves it, and irrelevant.
+    fn paired_store(root_sk: &PrivateKey) -> Store {
+        let store = test_store();
+        let _ = NodeDeviceRepository::new(&store)
+            .adopt_account(AccountGenesis::new(root_sk.public_key()))
+            .expect("adopt");
+        store
+    }
+
+    /// Only the holder stores scopes, so a cached certificate on a paired device
+    /// says nothing about where that device belongs.
+    #[test]
+    fn a_paired_device_binds_no_cached_sibling() {
+        let root_sk = PrivateKey::from([0x31; 32]);
+        let store = paired_store(&root_sk);
+        let namespace = test_group_id();
+        namespace_serving(&store, &namespace, APP_ONE);
+
+        assert_eq!(
+            planned(&store, &namespace, &known(&root_sk, 0x0C, vec![])),
+            BindOutcome::OutOfScope
+        );
     }
 
     #[test]

--- a/crates/governance-store/src/device_link.rs
+++ b/crates/governance-store/src/device_link.rs
@@ -30,7 +30,8 @@ enum BindPlan {
 /// Does this node know `cert`'s device belongs in `namespace`?
 ///
 /// Only the holder stores scopes, so a paired device cannot answer for any
-/// sibling and binds none.
+/// sibling and binds none. A holder answers for its own account alone: a
+/// certificate of any other account is out of scope in every namespace.
 fn in_scope_here(
     store: &Store,
     devices: &NodeDeviceRepository<'_>,
@@ -38,6 +39,14 @@ fn in_scope_here(
     cert: &KnownDeviceCert,
 ) -> EyreResult<bool> {
     if !devices.is_account_holder()? {
+        return Ok(false);
+    }
+    // A forced root import deletes the device row and keeps the cached
+    // certificates, so a holder's own cache can name a discarded account.
+    let Some(root) = devices.account_root()? else {
+        return Ok(false);
+    };
+    if cert.proof.statement.account != root.account() {
         return Ok(false);
     }
     // A namespace whose metadata has not synced names no application, and is
@@ -292,7 +301,6 @@ pub async fn bind_device_everywhere(
 #[cfg(test)]
 mod tests {
     use calimero_account::{AccountGenesis, AccountProof, DeviceCert, KemPublicKey};
-    use calimero_primitives::identity::PublicKey;
     use calimero_store::key::GroupMetaValue;
 
     use super::*;
@@ -304,13 +312,6 @@ mod tests {
 
     fn app(id: [u8; 32]) -> calimero_primitives::application::ApplicationId {
         calimero_primitives::application::ApplicationId::from(id)
-    }
-
-    /// The account root [`crate::test_fixtures::enrol_member`] derives for a
-    /// signing key, so a second device can be certified into the same account the
-    /// fixture already made a member.
-    fn account_root_of(sign_pk: &PublicKey) -> PrivateKey {
-        PrivateKey::from(*(*sign_pk))
     }
 
     /// A device of `root_sk`'s account, with `seed` deciding its id.
@@ -379,6 +380,19 @@ mod tests {
         }
     }
 
+    /// The root `test_store` provisioned: the account a holder node speaks for,
+    /// and so the only one whose devices it may bind.
+    fn holder_root(store: &Store) -> PrivateKey {
+        PrivateKey::from(
+            *NodeDeviceRepository::new(store)
+                .account_root()
+                .expect("read the account root")
+                .expect("an initialised node has one")
+                .signing_key()
+                .as_bytes(),
+        )
+    }
+
     /// A node whose device was adopted under another account's root: a paired
     /// phone. Its own root is present, as `merod init` leaves it, and irrelevant.
     fn paired_store(root_sk: &PrivateKey) -> Store {
@@ -389,17 +403,39 @@ mod tests {
         store
     }
 
-    /// Only the holder stores scopes, so a cached certificate on a paired device
-    /// says nothing about where that device belongs.
+    /// A node that cached certificates of its own account and was then adopted
+    /// into another: only the holder stores scopes, so the cache decides nothing.
     #[test]
     fn a_paired_device_binds_no_cached_sibling() {
-        let root_sk = PrivateKey::from([0x31; 32]);
-        let store = paired_store(&root_sk);
+        let store = paired_store(&PrivateKey::from([0x31; 32]));
         let namespace = test_group_id();
         namespace_serving(&store, &namespace, APP_ONE);
 
         assert_eq!(
-            planned(&store, &namespace, &known(&root_sk, 0x0C, vec![])),
+            planned(
+                &store,
+                &namespace,
+                &known(&holder_root(&store), 0x0C, vec![])
+            ),
+            BindOutcome::OutOfScope
+        );
+    }
+
+    /// A forced root import discards the account without deleting the
+    /// certificates cached for it, and leaves the node a holder again - so the
+    /// account is checked here rather than assumed from the row's presence.
+    #[test]
+    fn a_certificate_of_another_account_is_not_bound_here() {
+        let store = test_store();
+        let namespace = test_group_id();
+        namespace_serving(&store, &namespace, APP_ONE);
+
+        assert_eq!(
+            planned(
+                &store,
+                &namespace,
+                &known(&PrivateKey::from([0x32; 32]), 0x0D, vec![])
+            ),
             BindOutcome::OutOfScope
         );
     }
@@ -409,7 +445,7 @@ mod tests {
         let store = test_store();
         let ns = test_group_id();
         namespace_serving(&store, &ns, APP_ONE);
-        let root = PrivateKey::from([0x51; 32]);
+        let root = holder_root(&store);
 
         for scope in [vec![], vec![APP_ONE], vec![APP_TWO, APP_ONE]] {
             assert_eq!(
@@ -427,7 +463,7 @@ mod tests {
         let store = test_store();
         let ns = test_group_id();
         namespace_serving(&store, &ns, APP_ONE);
-        let root = PrivateKey::from([0x52; 32]);
+        let root = holder_root(&store);
 
         assert_eq!(
             planned(&store, &ns, &known(&root, 0x62, vec![APP_TWO])),
@@ -445,7 +481,7 @@ mod tests {
         let _key_id = GroupKeyring::new(&store, ns)
             .store_key(&[0x42; 32])
             .expect("store a scope key");
-        let root = PrivateKey::from([0x53; 32]);
+        let root = holder_root(&store);
 
         assert_eq!(
             planned(&store, &ns, &known(&root, 0x63, vec![])),
@@ -466,7 +502,7 @@ mod tests {
         let store = test_store();
         let ns = test_group_id();
         namespace_serving(&store, &ns, APP_ONE);
-        let root = PrivateKey::from([0x54; 32]);
+        let root = holder_root(&store);
         let cert = known(&root, 0x65, vec![APP_ONE]);
 
         AccountBindingRepository::new(&store)
@@ -484,7 +520,7 @@ mod tests {
         let store = test_store();
         let ns = test_group_id();
         namespace_serving(&store, &ns, APP_ONE);
-        let root = PrivateKey::from([0x55; 32]);
+        let root = holder_root(&store);
         let cert = known(&root, 0x66, vec![APP_ONE]);
 
         let _binding = AccountBindingRepository::new(&store)
@@ -525,7 +561,7 @@ mod tests {
                 },
             )
             .expect("save the namespace metadata");
-        let root = PrivateKey::from([0x56; 32]);
+        let root = holder_root(&store);
 
         assert_eq!(
             planned(&store, &ns, &known(&root, 0x67, vec![])),
@@ -578,7 +614,7 @@ mod tests {
         let (store, node_client, ack_router, ns_id, sk, _tmp, _msgs) =
             namespace_publish_fixture().await;
         let ns = ContextGroupId::from(ns_id.to_bytes());
-        let root = account_root_of(&sk.public_key());
+        let root = holder_root(&store);
         let devices = NodeDeviceRepository::new(&store);
 
         let in_scope = certify(&root, 0x71, [0x71; 32]);
@@ -637,7 +673,7 @@ mod tests {
         // A second namespace this node takes part in but holds no key for, which is
         // the ordinary "not caught up yet" state rather than a fault.
         let keyless = ContextGroupId::from([0xEE; 32]);
-        let root = account_root_of(&sk.public_key());
+        let root = holder_root(&store);
         let cert = KnownDeviceCert {
             proof: certify(&root, 0x77, [0x77; 32]),
             applications: Vec::new(),
@@ -687,7 +723,7 @@ mod tests {
         let (store, node_client, ack_router, ns_id, sk, _tmp, _msgs) =
             namespace_publish_fixture().await;
         let ns = ContextGroupId::from(ns_id.to_bytes());
-        let root = account_root_of(&sk.public_key());
+        let root = holder_root(&store);
         let devices = NodeDeviceRepository::new(&store);
 
         // An all-zero agreement key is a degenerate X25519 point: the scope key
@@ -759,7 +795,7 @@ mod tests {
         let (store, node_client, ack_router, ns_id, sk, _tmp, _msgs) =
             namespace_publish_fixture().await;
         let ns = ContextGroupId::from(ns_id.to_bytes());
-        let root = account_root_of(&sk.public_key());
+        let root = holder_root(&store);
 
         let revoked = certify(&root, 0x75, [0x75; 32]);
         NodeDeviceRepository::new(&store)
@@ -794,7 +830,7 @@ mod tests {
         let (store, node_client, ack_router, ns_id, sk, _tmp, _msgs) =
             namespace_publish_fixture().await;
         let ns = ContextGroupId::from(ns_id.to_bytes());
-        let root = account_root_of(&sk.public_key());
+        let root = holder_root(&store);
         let cert = certify(&root, 0x76, [0x76; 32]);
         NodeDeviceRepository::new(&store)
             .remember_device_cert(&cert, &[])

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -96,6 +96,7 @@ pub use self::contexts::{
 };
 pub use self::deny_list::DenyListRepository;
 pub use self::device_link::{bind_device_everywhere, bind_known_devices};
+pub(crate) use self::node_device::remember_sibling_cert_best_effort;
 pub use self::pending_rotation::{PendingDeviceRotationRepository, PendingRotationRepository};
 pub use self::reentry::ReentryRepository;
 

--- a/crates/governance-store/src/node_device.rs
+++ b/crates/governance-store/src/node_device.rs
@@ -1108,6 +1108,22 @@ impl<'a> NodeDeviceRepository<'a> {
         self.remember_device_cert(proof, &[])
     }
 
+    /// Cache a certificate of a sibling: another device of the account this node's
+    /// device speaks for. Widest scope, never overwriting one already known.
+    ///
+    /// # Errors
+    /// Propagates the store read or write failure.
+    pub fn remember_sibling_cert(&self, proof: &AccountProof<DeviceCert>) -> EyreResult<()> {
+        let Some(held) = self.get()? else {
+            return Ok(());
+        };
+        let cert = &proof.statement;
+        if held.account != cert.account || held.device() == cert.device {
+            return Ok(());
+        }
+        self.remember_device_cert_if_new(proof)
+    }
+
     /// The certificate this node holds for `device`, if it has one.
     ///
     /// # Errors
@@ -1193,6 +1209,15 @@ impl<'a> NodeDeviceRepository<'a> {
         let key = NodeDeviceIdentity::new();
         self.store.handle().delete(&key)?;
         Ok(())
+    }
+}
+
+/// The apply-time form: a node-local cache write must never refuse an op the
+/// group accepted, so failures are logged and swallowed.
+pub(crate) fn remember_sibling_cert_best_effort(store: &Store, proof: &AccountProof<DeviceCert>) {
+    if let Err(err) = NodeDeviceRepository::new(store).remember_sibling_cert(proof) {
+        tracing::warn!(device = %proof.statement.device, %err,
+                       "could not remember a sibling device's certificate");
     }
 }
 
@@ -1298,6 +1323,52 @@ mod tests {
             "a cert nothing else is known about reaches every namespace"
         );
         assert_eq!(repo.device_certs().expect("scan").len(), 2);
+    }
+
+    /// A sibling is a device of the account THIS node's device speaks for, which
+    /// on a paired node is not the account its own root owns.
+    #[test]
+    fn a_paired_device_caches_its_siblings_and_nobody_else() {
+        let store = test_store();
+        let repo = NodeDeviceRepository::new(&store);
+        let root_sk = PrivateKey::from([0x31; 32]);
+        let held = repo
+            .adopt_account(AccountGenesis::new(root_sk.public_key()))
+            .expect("adopt");
+
+        let sibling = certified(&root_sk, [0x42; 32], [0x52; 32]);
+        repo.remember_sibling_cert(&sibling).expect("cache");
+        assert!(repo
+            .device_cert(sibling.statement.device)
+            .expect("read")
+            .is_some());
+
+        let stranger = certified(&PrivateKey::from([0x33; 32]), [0x43; 32], [0x53; 32]);
+        repo.remember_sibling_cert(&stranger).expect("ignore");
+        assert!(repo
+            .device_cert(stranger.statement.device)
+            .expect("read")
+            .is_none());
+
+        let own = DeviceCert::sign(
+            &root_sk,
+            held.account,
+            held.device(),
+            &root(0x77),
+            &held.kem_public_key(),
+            0,
+            0,
+        )
+        .expect("sign");
+        repo.remember_sibling_cert(&AccountProof {
+            genesis: held.genesis,
+            chain: vec![],
+            statement: own,
+        })
+        .expect("ignore own");
+        assert!(repo.device_cert(held.device()).expect("read").is_none());
+
+        assert_eq!(repo.device_certs().expect("scan").len(), 1);
     }
 
     /// An empty scope is every application, and a named one is only its own -

--- a/crates/governance-store/src/node_device.rs
+++ b/crates/governance-store/src/node_device.rs
@@ -1101,7 +1101,7 @@ impl<'a> NodeDeviceRepository<'a> {
     ///
     /// # Errors
     /// Propagates the store read or write failure.
-    pub fn remember_device_cert_if_new(&self, proof: &AccountProof<DeviceCert>) -> EyreResult<()> {
+    fn remember_device_cert_if_new(&self, proof: &AccountProof<DeviceCert>) -> EyreResult<()> {
         if self.device_cert(proof.statement.device)?.is_some() {
             return Ok(());
         }
@@ -1113,7 +1113,7 @@ impl<'a> NodeDeviceRepository<'a> {
     ///
     /// # Errors
     /// Propagates the store read or write failure.
-    pub fn remember_sibling_cert(&self, proof: &AccountProof<DeviceCert>) -> EyreResult<()> {
+    fn remember_sibling_cert(&self, proof: &AccountProof<DeviceCert>) -> EyreResult<()> {
         let Some(held) = self.get()? else {
             return Ok(());
         };

--- a/crates/governance-store/src/node_device.rs
+++ b/crates/governance-store/src/node_device.rs
@@ -800,6 +800,22 @@ impl<'a> NodeDeviceRepository<'a> {
         Ok(true)
     }
 
+    /// Does this node's own root own the account its device speaks for?
+    ///
+    /// A node with a root and no device yet counts: it enrols under that root on
+    /// its first join. A paired node holds a device of somebody else's account.
+    ///
+    /// # Errors
+    /// Propagates the store read failure.
+    pub fn is_account_holder(&self) -> EyreResult<bool> {
+        let Some(root) = self.account_root()? else {
+            return Ok(false);
+        };
+        Ok(self
+            .get()?
+            .is_none_or(|held| held.account == root.account()))
+    }
+
     /// Just what the unwrap paths need: this node's device id and agreement
     /// secret, without resolving the account that owns them.
     ///
@@ -3080,6 +3096,33 @@ mod tests {
 
         assert!(!repo.remember_own_link(&sibling).expect("ignore"));
         assert!(repo.imported_certificate().expect("read").is_none());
+    }
+
+    /// The holder is the node whose root owns the account its device speaks for.
+    /// A node that has a root and no device yet is the holder too: it enrols under
+    /// that root on its first join.
+    #[test]
+    fn a_root_that_owns_the_device_makes_a_holder() {
+        let store = test_store();
+        let repo = NodeDeviceRepository::new(&store);
+        assert!(repo.is_account_holder().expect("root, no device"));
+        let _ = repo.ensure_enrolled(&test_group_id()).expect("enrol");
+        assert!(repo.is_account_holder().expect("root owns the device"));
+    }
+
+    #[test]
+    fn an_adopted_device_or_a_missing_root_is_not_the_holder() {
+        let other = AccountGenesis::new(PrivateKey::from([0x99; 32]).public_key());
+
+        let paired = test_store();
+        let repo = NodeDeviceRepository::new(&paired);
+        let _ = repo.adopt_account(other).expect("adopt");
+        assert!(!repo.is_account_holder().expect("device of another account"));
+
+        let rootless = test_store_without_account_root();
+        let repo = NodeDeviceRepository::new(&rootless);
+        let _ = repo.adopt_account(other).expect("adopt");
+        assert!(!repo.is_account_holder().expect("no root at all"));
     }
 
     /// Cold start: a root-free node adopts an account from its PUBLIC root key.

--- a/crates/governance-store/src/ops/group/account_ops.rs
+++ b/crates/governance-store/src/ops/group/account_ops.rs
@@ -125,8 +125,13 @@ pub(crate) fn apply_device_linked(
 
     match outcome {
         Ok(binding) => {
-            remember_own_link_if_ours(ctx, genesis, chain, cert);
-            remember_if_this_accounts_own(ctx, genesis, chain, cert);
+            let proof = AccountProof {
+                genesis: *genesis,
+                chain: chain.to_vec(),
+                statement: *cert,
+            };
+            remember_own_link_if_ours(ctx, &proof);
+            crate::remember_sibling_cert_best_effort(ctx.store(), &proof);
             tracing::info!(
                 group_id = ?group_id,
                 account = %binding.account,
@@ -154,37 +159,11 @@ pub(crate) fn apply_device_linked(
 
 /// Keep the proof if this link is about THIS node's device. Best-effort like the
 /// sibling cache: a node-local write must never refuse an op the group accepted.
-fn remember_own_link_if_ours(
-    ctx: &GroupApplyCtx<'_>,
-    genesis: &AccountGenesis,
-    chain: &[RootKeyHandoff],
-    cert: &DeviceCert,
-) {
-    let proof = AccountProof {
-        genesis: *genesis,
-        chain: chain.to_vec(),
-        statement: *cert,
-    };
-    if let Err(err) = crate::NodeDeviceRepository::new(ctx.store()).remember_own_link(&proof) {
-        tracing::warn!(device = %cert.device, %err,
+fn remember_own_link_if_ours(ctx: &GroupApplyCtx<'_>, proof: &AccountProof<DeviceCert>) {
+    if let Err(err) = crate::NodeDeviceRepository::new(ctx.store()).remember_own_link(proof) {
+        tracing::warn!(device = %proof.statement.device, %err,
                        "could not keep this device's own certificate");
     }
-}
-
-/// Cache a sibling's certificate, keyed on the account this node's DEVICE speaks
-/// for: on a paired node that is not the account its own root owns.
-fn remember_if_this_accounts_own(
-    ctx: &GroupApplyCtx<'_>,
-    genesis: &AccountGenesis,
-    chain: &[RootKeyHandoff],
-    cert: &DeviceCert,
-) {
-    let proof = AccountProof {
-        genesis: *genesis,
-        chain: chain.to_vec(),
-        statement: *cert,
-    };
-    crate::remember_sibling_cert_best_effort(ctx.store(), &proof);
 }
 
 /// `GroupOp::AccountDeviceUnlinked` — withdraw a device.

--- a/crates/governance-store/src/ops/group/account_ops.rs
+++ b/crates/governance-store/src/ops/group/account_ops.rs
@@ -171,48 +171,20 @@ fn remember_own_link_if_ours(
     }
 }
 
-/// Cache a certificate this node's OWN account root signed, wherever it applied
-/// from.
-///
-/// The multi-holder case: a second holder device certified a third, and this node
-/// learns of it only here. Without the cache, a namespace this node gains later
-/// would have no way to bind that device - the replicated binding row drops the
-/// root signature, so the certificate cannot be rebuilt from folded state.
-///
-/// Read-only on the root, never `ensure_account_root`: an apply path must not
-/// mint a key as a side effect of folding somebody else's op. A node holding no
-/// root owns no account and so can own no certificate here.
-///
-/// Failures are logged rather than propagated. The cache is an optimisation over
-/// re-pairing; refusing an op the group accepted because a node-local row could
-/// not be written would diverge this replica from its peers.
+/// Cache a sibling's certificate, keyed on the account this node's DEVICE speaks
+/// for: on a paired node that is not the account its own root owns.
 fn remember_if_this_accounts_own(
     ctx: &GroupApplyCtx<'_>,
     genesis: &AccountGenesis,
     chain: &[RootKeyHandoff],
     cert: &DeviceCert,
 ) {
-    let devices = crate::NodeDeviceRepository::new(ctx.store());
-    let own = match devices.account_root() {
-        Ok(Some(root)) => root.account(),
-        Ok(None) => return,
-        Err(err) => {
-            tracing::warn!(%err, "could not read this node's account root while folding a link");
-            return;
-        }
-    };
-    if own != cert.account {
-        return;
-    }
-    let proof = calimero_account::AccountProof {
+    let proof = AccountProof {
         genesis: *genesis,
         chain: chain.to_vec(),
         statement: *cert,
     };
-    if let Err(err) = devices.remember_device_cert_if_new(&proof) {
-        tracing::warn!(device = %cert.device, %err,
-                       "could not remember a certificate this account signed");
-    }
+    crate::remember_sibling_cert_best_effort(ctx.store(), &proof);
 }
 
 /// `GroupOp::AccountDeviceUnlinked` — withdraw a device.

--- a/crates/governance-store/src/ops/namespace/member_joined_open.rs
+++ b/crates/governance-store/src/ops/namespace/member_joined_open.rs
@@ -229,6 +229,10 @@ pub(super) fn record_join_credential(
         &account.statement,
     )?;
 
+    if outcome.is_ok() {
+        crate::remember_sibling_cert_best_effort(ctx.store(), account);
+    }
+
     // The endorsement, materialized. `AccountDeviceLinked` carries an explicit
     // `AccountMemberEndorsement` because an account root is a member nowhere, so
     // its gate has to ask whether some member vouched. A join already answers

--- a/crates/governance-store/src/ops/namespace/namespace_created.rs
+++ b/crates/governance-store/src/ops/namespace/namespace_created.rs
@@ -113,6 +113,9 @@ fn bind_founder(
     let bindings = crate::AccountBindingRepository::new(store);
     let outcome =
         bindings.apply_link(ns_gid, &account.genesis, &account.chain, &account.statement)?;
+    if outcome.is_ok() {
+        crate::remember_sibling_cert_best_effort(store, account);
+    }
     if let Err(rejected) = &outcome {
         if rejected.is_permanent() {
             // Refuse the genesis rather than establish a namespace its founder

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -10432,7 +10432,10 @@ mod parked_op_retries_to_success {
 mod account_plane_apply {
     use super::*;
     use calimero_account::{AccountGenesis, DeviceCert, DeviceId, KemPublicKey, RootKeyHandoff};
-    use calimero_context_client::local_governance::GroupOp;
+    use calimero_context_client::local_governance::{
+        GroupOp, JoinAccountCredential, NamespaceOp, RootOp, SignedNamespaceOp,
+    };
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
     use calimero_primitives::identity::PrivateKey;
     use calimero_store::Store;
 
@@ -10480,7 +10483,7 @@ mod account_plane_apply {
         let root = devices.provision_account_root().unwrap();
         // The cache now keys on the account this node's OWN enrolled device speaks
         // for, so a sibling link is only ever cached once this node has one.
-        devices.adopt_account(root.genesis()).unwrap();
+        let _held = devices.ensure_enrolled(&gid).unwrap();
         let account = root.account();
         let device = DeviceId::mint(account, [7u8; 16]);
         let cert = DeviceCert::sign(
@@ -10597,7 +10600,9 @@ mod account_plane_apply {
         let admin_sk = key(1);
         group_with_admin(&store, &gid, &admin_sk);
         let devices = crate::NodeDeviceRepository::new(&store);
-        let _own = devices.provision_account_root().unwrap();
+        // A holder's own device row, without which the cache would refuse at its
+        // first guard and never reach the account comparison this pins.
+        let _held = devices.ensure_enrolled(&gid).unwrap();
 
         let stranger_root = key(9);
         let genesis = AccountGenesis::new(stranger_root.public_key());
@@ -10635,6 +10640,174 @@ mod account_plane_apply {
             live_for(&store, &gid, account).len(),
             1,
             "the link itself must land - only the cache is scoped to our own account"
+        );
+        assert!(devices.device_cert(device).unwrap().is_none());
+    }
+
+    /// A namespace with an Open subgroup `member` may inherit into: the least
+    /// state a self-service join needs to reach the credential it carries.
+    fn open_subgroup_for(store: &Store, member: AccountId) -> ([u8; 32], ContextGroupId) {
+        let ns_id = [0xB7u8; 32];
+        let ns_gid = ContextGroupId::from(ns_id);
+        let subgroup = ContextGroupId::from([0xB8u8; 32]);
+        let admin = enrol_member(store, &ns_gid, &key(1).public_key());
+
+        let meta = MetaRepository::new(store);
+        meta.save(&ns_gid, &sample_meta_with_admin(admin)).unwrap();
+        meta.save(&subgroup, &sample_meta_with_admin(admin))
+            .unwrap();
+        let members = MembershipRepository::new(store);
+        members
+            .add_member(&ns_gid, &admin, GroupMemberRole::Admin)
+            .unwrap();
+        members
+            .add_member(&subgroup, &admin, GroupMemberRole::Admin)
+            .unwrap();
+        members
+            .add_member(&ns_gid, &member, GroupMemberRole::Member)
+            .unwrap();
+        NamespaceRepository::new(store)
+            .nest(&ns_gid, &subgroup)
+            .unwrap();
+        let caps = CapabilitiesRepository::new(store);
+        caps.set_subgroup_visibility(&subgroup, VisibilityMode::Open)
+            .unwrap();
+        caps.set_member_capability(
+            &ns_gid,
+            &member,
+            MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS.bits(),
+        )
+        .unwrap();
+
+        (ns_id, subgroup)
+    }
+
+    /// Fold `joiner_sk`'s inherited join of the Open subgroup, carrying `account`
+    /// as the credential the join binds.
+    fn join_open_subgroup(
+        store: &Store,
+        (ns_id, subgroup): ([u8; 32], ContextGroupId),
+        joiner_sk: &PrivateKey,
+        member: AccountId,
+        account: Box<JoinAccountCredential>,
+    ) {
+        let signed = SignedNamespaceOp::sign(
+            joiner_sk,
+            ns_id.into(),
+            vec![],
+            1,
+            crate::test_fixtures::seal_for_test(
+                store,
+                ContextGroupId::from(ns_id),
+                RootOp::MemberJoinedOpen {
+                    member,
+                    group_id: subgroup,
+                    account,
+                },
+            ),
+        )
+        .unwrap();
+        apply_signed_namespace_op(store, &signed).expect("the inherited open join applies");
+    }
+
+    /// The join feed into the same cache. A sibling's certificate reaches this
+    /// node inside the join op that device signs and nowhere else, so without
+    /// this write it could never be carried into a namespace gained later.
+    #[test]
+    fn a_siblings_join_credential_is_remembered_here() {
+        let store = test_store();
+        let devices = crate::NodeDeviceRepository::new(&store);
+        let root = devices.provision_account_root().unwrap();
+        let account = root.account();
+        let namespace = open_subgroup_for(&store, account);
+        let _held = devices
+            .ensure_enrolled(&ContextGroupId::from(namespace.0))
+            .unwrap();
+
+        let sibling_sk = key(0x21);
+        let credential = crate::test_fixtures::join_account_for(
+            root.signing_key(),
+            root.genesis(),
+            &sibling_sk.public_key(),
+            [0x21; 32],
+            0,
+        );
+        let device = credential.statement.device;
+
+        join_open_subgroup(&store, namespace, &sibling_sk, account, credential);
+
+        let held = devices
+            .device_cert(device)
+            .unwrap()
+            .expect("a sibling device of this account must be remembered from its join");
+        assert!(
+            held.applications.is_empty(),
+            "the wire carries no scope, so the widest one is the only honest guess"
+        );
+    }
+
+    /// The genesis feed. The founder is the one member no join op ever admits, so
+    /// its credential is seen here only in the genesis it signs.
+    #[test]
+    fn a_sibling_founding_a_namespace_is_remembered_here() {
+        let store = test_store();
+        let devices = crate::NodeDeviceRepository::new(&store);
+        let root = devices.provision_account_root().unwrap();
+        let _held = devices.ensure_enrolled(&test_group_id()).unwrap();
+
+        let founder_sk = key(0x24);
+        let credential = crate::test_fixtures::join_account_for(
+            root.signing_key(),
+            root.genesis(),
+            &founder_sk.public_key(),
+            [0x24; 32],
+            0,
+        );
+        let device = credential.statement.device;
+        let signed = SignedNamespaceOp::sign(
+            &founder_sk,
+            [0xB9u8; 32].into(),
+            vec![],
+            0,
+            NamespaceOp::Root(RootOp::NamespaceCreated {
+                founder: root.account(),
+                account: credential,
+            }),
+        )
+        .unwrap();
+
+        apply_signed_namespace_op(&store, &signed).expect("the genesis establishes the namespace");
+
+        let held = devices
+            .device_cert(device)
+            .unwrap()
+            .expect("a founder that is a sibling device of this account must be remembered");
+        assert!(
+            held.applications.is_empty(),
+            "the widest scope, as on the wire"
+        );
+    }
+
+    /// And only for siblings, through the join feed as through the link: a
+    /// stranger's device is somebody else's to extend.
+    #[test]
+    fn a_strangers_join_credential_is_not_remembered_here() {
+        let store = test_store();
+        let devices = crate::NodeDeviceRepository::new(&store);
+        let _held = devices.ensure_enrolled(&test_group_id()).unwrap();
+
+        let stranger_sk = key(0x23);
+        let credential = crate::test_fixtures::real_join_account(&stranger_sk.public_key());
+        let account = credential.statement.account;
+        let device = credential.statement.device;
+        let namespace = open_subgroup_for(&store, account);
+
+        join_open_subgroup(&store, namespace, &stranger_sk, account, credential);
+
+        assert_eq!(
+            live_for(&store, &ContextGroupId::from(namespace.0), account).len(),
+            1,
+            "the join itself must land - only the cache is scoped to our own account"
         );
         assert!(devices.device_cert(device).unwrap().is_none());
     }

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -10478,6 +10478,9 @@ mod account_plane_apply {
 
         let devices = crate::NodeDeviceRepository::new(&store);
         let root = devices.provision_account_root().unwrap();
+        // The cache now keys on the account this node's OWN enrolled device speaks
+        // for, so a sibling link is only ever cached once this node has one.
+        devices.adopt_account(root.genesis()).unwrap();
         let account = root.account();
         let device = DeviceId::mint(account, [7u8; 16]);
         let cert = DeviceCert::sign(

--- a/docs/src/content/docs/protocol/accounts.mdx
+++ b/docs/src/content/docs/protocol/accounts.mdx
@@ -286,6 +286,7 @@ Only the **current** scope key is delivered. Peers retain rotated-out keys, so h
 
 A paired device keeps the certificate its own link carried, so it can found or join a namespace as the account without an import step.
 A device paired before this change holds no such certificate, so the holder relinks it, or a certificate signed offline is imported with `merod account import-cert`.
+It also caches the certificates of its sibling devices as it folds their links and credentials, but binds none of them into a namespace it gains: application scope is stored only on the holder, which remains the one node that decides where a device belongs.
 
 ### Pairing is repeated, not a snapshot
 


### PR DESCRIPTION
## Summary

- `NodeDeviceRepository::is_account_holder` tells a node holding its own account's root from a paired one.
- The gain-time bind on a non-holder binds no cached device: only the holder stores application scopes.
- The holder binds devices of its own account only: a cached certificate naming any other account is out of scope in every namespace, which covers the certificate rows a forced `account import --force` leaves behind after it discards the account and deletes the device row.
- The sibling certificate cache keys on the enrolled device's account instead of the node's root, and is fed from founder and join credentials as well as link ops, so a paired device holds its siblings' proofs.

No wire or on-disk format changed: the cache row is the same `NodeAccountDeviceCertValue` under the same key, and only which node writes it changed.

Stacked on #3868. Part of #3806.

## Test plan

- [x] `cargo test -p calimero-governance-store` - 681 pass, including three new apply-level tests (a sibling's join credential and a sibling founder's genesis credential are cached; a stranger's is not) and the holder-account check in `device_link`.
- [x] `cargo test -p calimero-context` - 294 pass; it is the only other crate that drives the bind fan-out.
- [x] `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`, `cargo fmt --check`.

merobox, `merod:local` built from this branch, each scenario from a clean node state:

- [x] `account-paired-device-founds-namespace` - 15/15 steps; "Founding C did not change what the phone speaks as" green.
- [x] `account-pairing-application-scope` - 41/41 steps; the pair-complete refusals (400/400/409), the app-A-only reach, the relink widening, and revocation reaching A1, B1 and A2.
- [x] `account-facts-cross-namespace` - 26/26 steps; `revoked_in` contains both namespaces.
- [x] `shared-storage-account-writers-two-devices` - all steps.
- [x] `account-device-revoke-lockout` - all steps.
- [x] `account-root-backup-restore` - all steps.
- [ ] `account-pairing-missed-publish` - not runnable on the macOS host used here: its `partition_peers` step shells out to `sudo iptables` on the host, which needs a Linux host with passwordless sudo. It failed at that step before reaching any assertion; CI runs it on Linux.
