### PR TITLE
ci(deps): stop proposing libp2p satellites ahead of the meta-crate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,23 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "wasmer-middlewares"
         update-types: ["version-update:semver-major"]
+
+      # libp2p 0.56 is the latest release and still requires multiaddr 0.18 and
+      # libp2p-identity 0.2, which it bakes into libp2p-swarm and libp2p-kad
+      # signatures. Bumping a satellite alone puts two Multiaddr/PeerId types in
+      # the graph and crates/network stops compiling -- 252 errors in #3721, and
+      # again in #3861 once a new satellite released. Nothing in core can
+      # reconcile it, so the group cannot help while the meta-crate lags.
+      #
+      # These are 0.x, so minor is the breaking axis and is ignored with major;
+      # patches still arrive. Drop this once a libp2p release requires
+      # multiaddr ^0.19 / libp2p-identity ^0.3.
+      - dependency-name: "multiaddr"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "libp2p-identity"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "prometheus-client"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
       # Families that version in lockstep, matched first so no member is ever bumped alone:
       # each appears in the others' public API, so a lone bump lands two incompatible types.


### PR DESCRIPTION
## Summary
- Ignores major and minor updates for `multiaddr`, `libp2p-identity` and `prometheus-client` until the `libp2p` meta-crate catches up. They are `0.x`, so minor is the breaking axis; patches still arrive.
- `libp2p` 0.56.0 is the latest release and still requires `multiaddr 0.18.1` / `libp2p-identity 0.2.12`, and it bakes those types into `libp2p-swarm` and `libp2p-kad` signatures. A satellite bumped alone puts two `Multiaddr`/`PeerId` types in the graph and `crates/network` stops compiling - 252 errors in #3721, and the identical failure again in #3861 once a new satellite released.
- The existing `libp2p` group cannot prevent this: it only stops a member being bumped *alone within the group*, and there is no newer meta-crate to bump to. Follows the `wasmer` precedent directly above it.

## Test plan
- [x] `.github/dependabot.yml` parses; the cargo ecosystem's `ignore` list has 6 entries
- [ ] #3861 closed as unmergeable; the next satellite release should no longer open a PR
