### PR TITLE
fix(context): let a join response's group key displace a held one

### DIFF
--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -262,13 +262,22 @@ impl Handler<JoinGroupRequest> for ContextManager {
                 };
 
                 // Unwrap and store the group key.
+                //
+                // The join response wins over whatever the keyring already
+                // holds, and that is a deliberate reversal (#3891). This used to
+                // skip on "a key is already present", which reads as harmless
+                // caution and is the step that makes a wrong key PERMANENT: the
+                // response is authenticated and addressed to this joiner for
+                // this group, so it is better evidence of the group's key than
+                // an entry of unknown provenance that happens to be in the
+                // keyring. Preferring the local one meant a key planted before
+                // the join could never be corrected — the membership-driven pull
+                // reports only *keyless* groups, so nothing re-drives a node
+                // holding the wrong key, and a delivery may no longer replace a
+                // held key (#3887). This was the last correction path and it was
+                // declining to correct.
                 if !join_result.has_key() {
                     warn!("join response contained no group key");
-                } else if GroupKeyring::new(&datastore, group_id).load_current_key()?.is_some() {
-                    info!(
-                        ?group_id,
-                        "group key already present locally, skipping store from join response"
-                    );
                 } else {
                     let envelope: calimero_context_client::local_governance::KeyEnvelope =
                         borsh::from_slice(&join_result.key_envelope_bytes)
@@ -280,13 +289,46 @@ impl Handler<JoinGroupRequest> for ContextManager {
                         None,
                         &envelope,
                     )?;
-                    crate::group_key_pull::adopt_pulled_group_key(
-                        &datastore,
-                        namespace_id.into(),
-                        group_id,
-                        &group_key,
-                    )?;
-                    info!("received group key via direct join response");
+                    let offered_key_id = GroupKeyring::key_id_for(&group_key);
+                    let held_key_id = GroupKeyring::new(&datastore, group_id)
+                        .load_current_key()?
+                        .map(|(key_id, _)| key_id);
+
+                    match join_key_action(held_key_id, offered_key_id) {
+                        JoinKeyAction::AlreadyHeld => {
+                            info!(?group_id, "join response carried the group key already held");
+                        }
+                        // Worth shouting about. Either something planted a key
+                        // for this group before the join, or the group rotated
+                        // and this node is behind. Both resolve the same way --
+                        // take the authenticated one -- but an operator should
+                        // see that a displacement happened.
+                        JoinKeyAction::Displace { held_key_id } => {
+                            warn!(
+                                ?group_id,
+                                held_key_id = %hex::encode(held_key_id),
+                                adopted_key_id = %hex::encode(offered_key_id),
+                                "the join response's group key differs from the one already held; \
+                                 adopting the join response's key and displacing the local one, \
+                                 which was not attested by this join"
+                            );
+                            let _ = crate::group_key_pull::adopt_pulled_group_key(
+                                &datastore,
+                                namespace_id.into(),
+                                group_id,
+                                &group_key,
+                            )?;
+                        }
+                        JoinKeyAction::Seed => {
+                            let _ = crate::group_key_pull::adopt_pulled_group_key(
+                                &datastore,
+                                namespace_id.into(),
+                                group_id,
+                                &group_key,
+                            )?;
+                            info!("received group key via direct join response");
+                        }
+                    }
                 }
 
                 // Issue #2256 / PR #2368: write the namespace's
@@ -862,6 +904,43 @@ impl Handler<JoinGroupRequest> for ContextManager {
     }
 }
 
+/// What to do with the group key a join response carried.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JoinKeyAction {
+    /// Nothing held for this group: store it.
+    Seed,
+    /// The key held is the one offered. Storing it again is a no-op.
+    AlreadyHeld,
+    /// A DIFFERENT key is held. Take the join response's and displace it.
+    Displace { held_key_id: [u8; 32] },
+}
+
+/// Decide between the key a join response carried and the one already held.
+///
+/// The join response wins, and that is a deliberate reversal (#3891). This
+/// decision used to be "if any key is present, skip" — which reads as harmless
+/// caution and is the step that makes a wrong key PERMANENT. The response is
+/// authenticated and addressed to this joiner for this group, so it is better
+/// evidence of the group's key than an entry of unknown provenance that happens
+/// to be in the keyring.
+///
+/// It was also the last correction path left. The membership-driven pull reports
+/// only *keyless* groups (`groups_member_but_keyless`), so nothing re-drives a
+/// node holding the wrong key; and a delivery may no longer replace a held key
+/// (#3887). So a key planted before the join could never be corrected, and this
+/// function was the thing declining to correct it.
+///
+/// Split out from the handler so the decision is testable without mocking the
+/// join transport: it is the security-relevant half, and the rest of that block
+/// is unwrapping and storing.
+fn join_key_action(held_key_id: Option<[u8; 32]>, offered_key_id: [u8; 32]) -> JoinKeyAction {
+    match held_key_id {
+        None => JoinKeyAction::Seed,
+        Some(held) if held == offered_key_id => JoinKeyAction::AlreadyHeld,
+        Some(held) => JoinKeyAction::Displace { held_key_id: held },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -876,6 +955,49 @@ mod tests {
 
     use super::*;
     use crate::test_support::{actor, certify_device};
+
+    /// A join response's key displaces an unattested held key (#3891).
+    ///
+    /// The reversal, and the case a poisoned node depends on. Before this,
+    /// holding *any* key meant the join response's was skipped — so a key
+    /// planted before the join stayed, and nothing else could correct it: the
+    /// membership-driven pull enumerates only keyless groups, and #3887 stopped
+    /// a delivery from replacing a held key. The join response is authenticated
+    /// and addressed to this joiner for this group, so it is the better
+    /// evidence.
+    #[test]
+    fn a_join_responses_key_displaces_a_different_held_key() {
+        let planted = [0xAA; 32];
+        let authentic = [0xBB; 32];
+        assert_eq!(
+            join_key_action(Some(planted), authentic),
+            JoinKeyAction::Displace {
+                held_key_id: planted
+            },
+            "the join response wins over a key of unknown provenance, and the displaced \
+             id is carried out so the log can name it"
+        );
+    }
+
+    /// Re-joining is idempotent and quiet.
+    ///
+    /// This is what keeps the reversal from being noisy: a retry, or a second
+    /// join of a group whose key is already correct, must not report a
+    /// displacement, because storing the same key again changes nothing.
+    #[test]
+    fn a_join_response_carrying_the_held_key_is_a_no_op() {
+        let key_id = [0xCC; 32];
+        assert_eq!(
+            join_key_action(Some(key_id), key_id),
+            JoinKeyAction::AlreadyHeld
+        );
+    }
+
+    /// The ordinary first join: nothing held, so seed it.
+    #[test]
+    fn a_join_response_seeds_when_no_key_is_held() {
+        assert_eq!(join_key_action(None, [0xDD; 32]), JoinKeyAction::Seed);
+    }
 
     const APP: [u8; 32] = [0xD1; 32];
     const GROUP: [u8; 32] = [0xD2; 32];


### PR DESCRIPTION
# [context] let a join response's group key displace a held one

First of the three items on #3891, and the load-bearing one.

## Description

`join_group` skipped storing the group key its own join response carried, whenever the keyring already held one:

```rust
} else if GroupKeyring::new(&datastore, group_id).load_current_key()?.is_some() {
    info!(?group_id, "group key already present locally, skipping store from join response");
```

That reads as harmless caution, which is presumably why it survived. It is the step that makes a **wrong** key permanent.

The join response is authenticated and addressed to this joiner for this group, so it is better evidence of the group's key than an entry of unknown provenance that happens to be in the keyring. And it was **the last correction path left**:

- the membership-driven pull enumerates only *keyless* groups (`groups_member_but_keyless`, `namespace/retry.rs:172-178`), so nothing re-drives a node holding a wrong key — it is indistinguishable from a healthy one;
- a delivery may no longer replace a held key (#3887), correctly, but that removes delivery as a correction route too.

So a key planted for a subgroup before the victim joined it could never be corrected, and this line was the thing declining to correct it.

**The response now wins.** On a differing key the displacement is a `warn!` naming both ids, because it means either something planted a key or this node is behind a rotation — an operator should see that, not have it pass as routine.

### The decision is split out

`join_key_action(held_key_id, offered_key_id) -> JoinKeyAction` is the security-relevant half of that block; the rest is unwrapping and storing. Extracting it means the three outcomes are testable without mocking the join transport, which is what the handler's existing `#[actix::test]` would otherwise need.

`AlreadyHeld` matters as much as `Displace`: without it, an ordinary re-join or a retry would report a displacement that did not happen, and a `warn!` that cries wolf gets filtered.

## What I checked before writing it

`adopt_pulled_group_key` (`crates/context/src/group_key_pull.rs:22-43`) calls `GroupKeyring::store_key` **directly** rather than going through `apply_received_group_key_envelope_at_depth` — so #3887's seed-not-replace rule does not apply on this path and the adoption really lands. An epoch-`0` store with a later `insertion_seq` outranks the held epoch-`0` key, per `key_rank`.

Had that helper routed through the guarded path, **this fix would have been silently inert** — it would have compiled, logged the displacement, and changed nothing.

## Test plan

```
  Cargo format                     ok              3.9s
  Naming gate                      ok              0.2s
  Cargo clippy                     ok             42.5s
  Cargo clippy (mock-attestation)  ok             41.4s
4/4 passed
```

via `./scripts/check-like-ci.py` (#3883). Plus every `calimero-context` target:

```bash
cargo test -p calimero-context --no-fail-fast
# 296 lib + all 11 integration targets, 0 failed
```

Three tests, one per outcome:

| test | what it pins |
| --- | --- |
| `a_join_responses_key_displaces_a_different_held_key` | the reversal, and the case a poisoned node depends on. Asserts the displaced id is carried out, so the log can name it |
| `a_join_response_carrying_the_held_key_is_a_no_op` | a retry or ordinary re-join reports nothing — what keeps the `warn!` meaningful |
| `a_join_response_seeds_when_no_key_is_held` | the ordinary first join still works |

**Not run: merobox.** Confirmed unavailable here — the `docker` binary is present but its daemon is unreachable, and `merobox` is not installed. This one *is* expressible as a scenario, unlike the other findings in this series: plant a key via a delivery, then join, then assert the group's traffic decrypts. Worth adding when someone has a daemon.

## Proof the fix works

**Before:** with any key held, the handler logged *"group key already present locally, skipping store from join response"* and discarded the authenticated key. In the #3891 scenario the node then encrypts its group ops under the planted key, is not enumerated by `groups_member_but_keyless` because it is not keyless, and cannot be corrected by delivery because of #3887.

**After:** `join_key_action(Some(planted), authentic)` returns `Displace { held_key_id: planted }`, the handler adopts the authenticated key, and the displacement is logged with both ids.

The three tests are the before/after in the same place: the first would have been `Skip` under the old logic, and the other two assert the paths that must not change.

## Wire contract (SDK gate)

No HTTP wire DTO, route, on-disk format or op encoding changed. `join_key_action` is a private helper.

- [ ] Regenerated wire fixtures — not applicable
- [ ] Updated `crates/server/endpoints.json` — not applicable
- [ ] Linked the matching mero-js PR — not applicable

**No coordinated upgrade.** A node running this adopts a key it was already sent and previously threw away.

## What this does not fix

The other two items on #3891, both of which touch code #3887 is currently changing and so follow once it merges:

1. **#3875's namespace-anchor fallback answers "unfolded" from purely local state**, so it spans every member's entire pre-join window rather than a genuine race, and lets a namespace anchor authorize a key for a **Restricted** subgroup it is not in — crossing the #3858/#3860 boundary.
2. **No sibling to `groups_member_but_keyless`** that reports a member group whose held key is attested by no admin-signed rotation and no join record, so a wrong-key node is re-driven rather than looking healthy.

This PR means such a node is corrected *if it later joins the group through the normal path*, which is the common case but not all of them.

## Related

- #3891 — this PR's issue; two items remain open on it.
- #3887 — refuses a delivery that would replace a held key. Correct, and it is what removed the other correction route, which is why this one matters.
- #3892 / #3888 — the pull-path counterpart: only a trusted anchor may serve a group key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_