### PR TITLE
feat(node,ci): report which ground authorized each group-key recovery

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -1283,6 +1283,41 @@ jobs:
           fi
           echo "no blob chunk hash mismatches — every chunk served passed its content-hash check"
 
+      - name: Report which ground authorized each group-key recovery (observe-only)
+        if: always()
+        run: |
+          # `key_server_accepted` allows exactly two grounds: the responder is a
+          # trusted anchor of the group, or it proved with a certificate chaining
+          # to this node's account root that it is a device of this node's OWN
+          # account (#3888, #3892). Every scenario that exercises the key pull
+          # passed before the second ground existed, so a green suite is not
+          # evidence that it works -- and it shipped INERT once already, because
+          # a node that provisioned its own root holds no certificate for its own
+          # device, so the proof was always empty and acceptance quietly
+          # collapsed back to anchor-only. Two red rounds and a security hole
+          # came out of that, and the suite could not have told us.
+          #
+          # So this reports the distribution rather than asserting one: nobody
+          # yet knows which ground each scenario legitimately uses, and pinning a
+          # guess is how a gate starts failing for the wrong reason. Observe
+          # first, assert once the distribution is known -- the same way the
+          # projection and op-store gates were built. INFORMATIONAL, never fails.
+          #
+          # ANSI escapes sit between a field name and its `=` in node logs, so
+          # the sed is not optional; matching the raw pattern finds nothing.
+          if grep -rl "key_recovery_authorized_by" docker-logs/ 2>/dev/null | grep -q .; then
+              echo "group-key recoveries by authorizing ground:"
+              grep -rho 'key_recovery_authorized_by.*' docker-logs/ \
+                | sed -E $'s/\x1B\\[[0-9;]*[mK]//g' \
+                | grep -oE 'key_recovery_authorized_by="?[a-z_]+"?' | sort | uniq -c | sort -rn
+          else
+              # Not a failure: most scenarios never need the direct pull at all,
+              # because the delivery reaches them first. Silence here and silence
+              # from a broken marker look identical, which is why the suite-wide
+              # view is what matters rather than any one scenario.
+              echo "no key_recovery_authorized_by markers - this scenario recovered no group key by direct pull"
+          fi
+
       - name: Report scope_root governance-divergence pulls (P6.S2, observe-only)
         if: always()
         run: |

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -2116,9 +2116,26 @@ impl SyncManager {
                 drop(store);
                 match outcome {
                     Ok(divergence) => {
+                        // `key_recovery_authorized_by` names WHICH of the two
+                        // grounds let this responder serve, because "a key was
+                        // recovered" and "the ground added by #3892 was the
+                        // reason" are not the same claim. Every scenario that
+                        // exercises this path passed before that ground existed,
+                        // so a green run is not evidence the own-account path
+                        // works -- and it shipped inert once already, for a node
+                        // that had no certificate for its own device to attach.
+                        // Emitted as a marker so the suite can report which
+                        // grounds real traffic actually uses; observe first,
+                        // assert once that distribution is known, which is how
+                        // the projection and op-store gates were built.
                         info!(
                             namespace_id = %hex::encode(namespace_id),
                             group_id = %hex::encode(group_id),
+                            key_recovery_authorized_by = if is_anchor {
+                                "anchor"
+                            } else {
+                                "own_account_device"
+                            },
                             "recovered group key via direct delivery"
                         );
                         if let Some(report) = divergence {


### PR DESCRIPTION
# [node, ci] report which ground authorized each group-key recovery

Closes the coverage gap behind #3892's two red E2E rounds. Observe-only: one log field, one informational workflow step, no assertion.

## Description

`key_server_accepted` allows exactly two grounds for serving a group key (#3888, #3892):

- the responder is a **trusted anchor** of the group;
- or it proved, with a certificate chaining to this node's account root, that it is a device of **this node's own account**.

The accept path logged `"recovered group key via direct delivery"` and **not which one**. So the suite could tell us a key arrived, never that the second ground was the reason it arrived.

**That distinction is not academic.** Every scenario exercising this path passed before the own-account ground existed — and it then shipped **inert**: a node that provisioned its own root holds no certificate for its own device, so the proof was always empty and acceptance quietly collapsed back to anchor-only. Two red E2E rounds and one security hole (a replayable public certificate) came out of that. A green suite could not have distinguished the working mechanism from the broken one, because "a key was recovered" was true in both cases.

`key_recovery_authorized_by` now names the ground, and a new workflow step reports the distribution across each scenario's node logs.

### Why this asserts nothing

Deliberate. Nobody yet knows which ground each scenario legitimately uses — in a three-node mesh the anchor and the own-account sibling may both be reachable, and which one answers first is not fixed. Pinning a guess is how a gate starts failing for the wrong reason, and I would rather add a step that reports than one I have to keep re-tuning.

Observe first, assert once the distribution is known. That is how the `unified_projection_*` and `op_store_incomplete` gates in this same workflow were built, and their comments say so: *"Observe-only per scenario, and deliberately so."*

## Test plan

```
  Cargo format                     ok              4.0s
  Naming gate                      ok              0.1s
  Cargo clippy                     ok             45.7s
  Cargo clippy (mock-attestation)  ok             41.9s
4/4 passed
```

via `./scripts/check-like-ci.py` (#3883), plus `cargo test -p calimero-node --lib` → **586 passed, 0 failed**.

**The extraction pipeline was validated locally**, against synthetic ANSI-styled log lines in both field forms:

```
      1 key_recovery_authorized_by=anchor
      1 key_recovery_authorized_by="own_account_device"
```

That check is not ceremony. `tracing` writes escapes *between* a field name and its `=`, so the raw pattern silently matches nothing — the exact failure the neighbouring steps in this workflow carry warnings about (*"which is how 'planes seen:' used to print an empty list under a failing gate"*). The YAML was also parsed to confirm the step is well-formed.

**Not run: merobox.** Confirmed unavailable here — the `docker` binary is present but its daemon is unreachable, and `merobox` is not installed. This PR's own E2E run is what produces the first distribution, which is the point of it.

## What this does and does not change

- **Behaviour: none.** One `info!` field added on a path that already logged, and one `if: always()` reporting step that never fails.
- No HTTP wire DTO, route, on-disk format or op encoding changed.

- [ ] Regenerated wire fixtures — not applicable
- [ ] Updated `crates/server/endpoints.json` — not applicable
- [ ] Linked the matching mero-js PR — not applicable

## A correction worth recording

I repeatedly described the key-delivery paths as having "no merobox coverage". Auditing the suite before writing anything, that was **too strong**: 20+ of the 68 scenarios touch key delivery, pull, or subgroup keys, and that coverage is exactly why four regressions were caught today rather than shipped.

The accurate gap is narrower and is what this PR addresses: the *paths* are exercised, but the *security properties* the recent fixes established are not distinguished from the behaviour that preceded them. Attack coverage remains out of reach for a different reason — the suite has no step type that emits a hand-crafted governance op, so "a stranger mints a `key_id`" is not expressible in YAML at all.

I also considered asserting the `"deferring a KeyDelivery"` marker from #3895 and did not: it only appears when the delivery wins a race against `GroupCreated`, so asserting it would be flaky by construction.

## Related

- #3892 — added the own-account ground this reports on (merged as `a76005de`).
- #3888 — closed; the forgeable-`key_id` widening.
- #3894 — records the traps that made the inert shipment possible.
- #3895 — the deferral fix, in flight; its marker is deliberately not asserted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_