### PR TITLE
chore(release): 0.11.0-rc.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.32"
+version = "0.11.0-rc.33"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
> [!WARNING]
> **Do not merge this without reading the two blockers below.**
> `release.yml` triggers on *push to master touching `Cargo.toml`*, so **merging this PR is the release** — it publishes binaries, Docker images and the Homebrew formula, and mints the `0.11.0-rc.33` tag every downstream repo pins to. There is no separate "cut" step to reconsider at.

One line, the same shape as every previous cut (#3821 for rc.32):

```diff
 [workspace.metadata.workspaces]
-version = "0.11.0-rc.32"
+version = "0.11.0-rc.33"
```

## Blocker 1 — master's E2E is red, and has been since 2026-09-09

`E2E - Rust Apps` has failed on master four consecutive runs:

```
failure  2026-09-10 09:05  21eae203
failure  2026-09-10 06:35  a76005de
failure  2026-09-10 04:44  9b673017
failure  2026-09-09 20:45  8903e024   <- first red
success  2026-09-09 15:40  549e0512   <- last green
```

Always the same job: **`Test (group-kick-and-readd-deny-list)`**. The symptom is one node returning `HTTP 500` on `groupStateHash` while the other two converge to the same hash — `MemberAdded` + `KeyDelivery` not propagating inside 61s.

Four in a row after a clean run reads as a **regression introduced in `549e0512..8903e024`**, not the known intermittent KeyDelivery timing flake. Cutting rc.33 today tags a tree with a live group kick/re-add defect in it, and every downstream repo pins to that tag.

**Nobody has bisected that range yet.**

## Blocker 2 — decide whether #3899 belongs in this release

calimero-network/core#3899 adds `category` to the bundle manifest, and the App Registry's new upload policy (calimero-network/app-registry#273) cannot enforce the category requirement until a *released* cargo-mero carries the field — its metadata table is `deny_unknown_fields`, so `category = "games"` is a build error on rc.32.

- **If #3899 lands first**, rc.33 unblocks the registry gate, and the follow-up is a one-line bump of `default:` in `apps/.github/actions/install-cargo-mero/action.yml`.
- **If it does not**, the registry stays on its `tags`-derived fallback until rc.34.

#3899 is green apart from the same inherited `group-kick-and-readd-deny-list` failure.

## What is NOT in this PR

No changelog, no tag, no `Cargo.lock` change — matching #3821, which touched `Cargo.toml` alone. The `[workspace.metadata.workspaces]` comment points at `docs/RELEASE.md`, which **does not exist in the tree**; worth either restoring or fixing that reference, separately from this.

Opened deliberately as a parked PR. Merging is a human decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)