### PR TITLE
chore(fleet): bump calimero-studio on release, and teach the script its shape

### DIFF
--- a/.github/fleet.json
+++ b/.github/fleet.json
@@ -8,6 +8,14 @@
     "  npm   — declares @calimero-network/* packages in some package.json",
     "  tauri — links no SDK; ships a merod BINARY named in merod-config.json",
     "",
+    "A consumer's manifests need not sit at either known path. calimero-studio's",
+    "pins are workspace roots at foundation-app/base/logic/Cargo.toml — the",
+    "scaffold template every generated app is built from — and",
+    "foundation-app/recipes/Cargo.toml, the compiler-checked CRDT idioms the build",
+    "agent reads. bump-fleet.sh calls that the `nested` shape and finds them by",
+    "looking for any Cargo.toml in the tree that pins core, so a repository does",
+    "not have to be reshaped to be bumpable.",
+    "",
     "A core release moves `cargo` and `tauri`. `npm` is recorded because the same",
     "shape of file is read by the equivalent workflow in mero-js, mero-react and",
     "design-system; fleet-bump.yml here selects cargo and tauri only.",
@@ -34,7 +42,21 @@
     "so bump_cargo_workspace re-reads what it wrote and asserts the same two",
     "invariants the repo's own scripts/check-app-metadata.sh asserts in CI, plus",
     "the toolchain pins that CI does NOT check and which had already drifted three",
-    "releases by the time this was written."
+    "releases by the time this was written.",
+    "",
+    "WHAT A CORE RELEASE DOES NOT MOVE, AND MUST NOT PRETEND TO.",
+    "calimero-studio also pins merobox (foundation-app/base/scripts/install-merobox.sh)",
+    "and carries a cargo-mero FLOOR_VERSION. Neither tracks a core tag: the floor",
+    "is the oldest release shipping a cargo-mero asset, and merobox has its own",
+    "release train whose compatible pair with a given core is evidence, not",
+    "arithmetic. This script leaves both alone rather than guessing.",
+    "",
+    "And a bump pull request only moves PINS. When a release is a source-level",
+    "break — rc.32's #3807 required every Mergeable type to declare how it merges —",
+    "the pull request it opens is red until someone writes the code. That is the",
+    "signal working, not the automation failing: before calimero-studio was listed",
+    "here nothing opened a pull request at all, and its pin sat twelve releases",
+    "behind until a weekly cron caught it."
   ],
 
   "consumers": [
@@ -43,7 +65,8 @@
     { "repo": "mero-ar", "surfaces": ["cargo"] },
     { "repo": "mero-tag", "surfaces": ["cargo"] },
     { "repo": "tauri-app", "surfaces": ["npm", "tauri"] },
-    { "repo": "app-registry", "surfaces": ["npm"] }
+    { "repo": "app-registry", "surfaces": ["npm"] },
+    { "repo": "calimero-studio", "surfaces": ["cargo"] }
   ],
 
   "_migrated_note": [

--- a/.github/scripts/bump-fleet.sh
+++ b/.github/scripts/bump-fleet.sh
@@ -109,10 +109,12 @@ fi
 # others, so the matcher tolerates both.
 
 # The monorepo lays the same surface out differently, so `cargo` means one of
-# two shapes and the script decides which by looking rather than by being told.
+# three shapes and the script decides which by looking rather than by being told.
 #
 #   standalone   logic/Cargo.toml            one contract, its own pins
 #   workspace    Cargo.toml [workspace]      apps/*/logic, one shared pin
+#   nested       neither, but some Cargo.toml
+#                deeper in the tree pins core  calimero-studio
 #
 # calimero-network/apps is the second: nine contracts whose SDK tag lives once,
 # in [workspace.dependencies]. That is the whole reason the monorepo exists —
@@ -151,6 +153,44 @@ app_manifests() {
 scenario_files() {
   find "$DIR/apps" -type f -path '*/logic/workflows/*' \
        \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | sort
+}
+
+# Every Cargo.toml anywhere in the tree that pins core by git tag, for a repo
+# whose manifests sit at neither of the two known paths. calimero-studio is the
+# case: its pins are workspace roots at foundation-app/base/logic/Cargo.toml (the
+# scaffold template every generated app is built from) and
+# foundation-app/recipes/Cargo.toml (compiler-checked CRDT idioms the build agent
+# reads), and it had drifted TWELVE releases behind before anything noticed,
+# because no release opened a pull request here.
+#
+# Only workspace roots and standalone crates match: a member crate says
+# `calimero-sdk = { workspace = true }` and carries no git URL, so the grep
+# excludes it and the tag stays in exactly one place per workspace.
+#
+# `target/` and `node_modules/` are excluded because a vendored or built copy of
+# someone else's manifest is not this repository's pin.
+nested_core_manifests() {
+  find "$DIR" -type f -name 'Cargo.toml' \
+       -not -path '*/target/*' \
+       -not -path '*/node_modules/*' \
+    2>/dev/null | sort | while IFS= read -r m; do
+      # `if`, not `[ ... ] &&`: a false test as the loop's last command makes the
+      # loop — and so this function — exit 1, which under `set -e` kills the
+      # assignment that captured its output. Silently, with no diagnostic.
+      if [ -n "$(core_tag_in "$m")" ]; then printf '%s\n' "$m"; fi
+    done
+}
+
+# Every merobox scenario / workflow document in the tree, for the nested shape.
+# The exclusions mirror `tooling_files`: a recorded measurement or a committed
+# log states the conditions it ran under, and rewriting those rewrites history.
+nested_scenario_files() {
+  find "$DIR" -type f \( -name '*.workflow.yml' -o -name '*.workflow.yaml' \) \
+       -not -path '*/target/*' \
+       -not -path '*/node_modules/*' \
+       -not -path '*/logs/*' \
+       -not -path '*/test/perf/*' \
+    2>/dev/null | sort
 }
 
 bump_cargo_workspace() {
@@ -555,10 +595,115 @@ bump_cargo() {
     bump_cargo_app
   elif [ -f "$DIR/Cargo.toml" ] && grep -q 'calimero-network/core' "$DIR/Cargo.toml"; then
     bump_cargo_workspace
+  elif [ -n "$(nested_core_manifests)" ]; then
+    bump_cargo_nested
   else
-    note "no logic/Cargo.toml, and no workspace root pinning calimero-network/core"
+    note "no logic/Cargo.toml, no workspace root pinning calimero-network/core,"
+    note "and no Cargo.toml anywhere in the tree that pins it either"
     exit 3
   fi
+}
+
+# ---------------------------------------------------------------------------
+# nested: the pins are somewhere else entirely
+# ---------------------------------------------------------------------------
+#
+# One or more workspace roots deeper in the tree, each with its own lockfile,
+# plus the merod images that have to move with them. Unlike the workspace shape
+# there is no derived-value contract to re-assert afterwards: nothing here
+# declares min-runtime-version (it is rewritten where present, and its absence
+# is not an error), and no check-app-metadata.sh equivalent exists to be kept
+# happy. So the verification is the narrow, honest one — every manifest touched
+# now pins the new tag, and none still pins another.
+bump_cargo_nested() {
+  local manifests
+  manifests=$(nested_core_manifests)
+
+  local first current
+  first=$(printf '%s\n' "$manifests" | head -1)
+  current=$(core_tag_in "$first")
+
+  head_note "cargo (nested): $current -> $VERSION"
+
+  # Every manifest already there means nothing to do. Checked across all of
+  # them, not just the first: two roots at different tags IS the drift, and
+  # exiting 4 off the first one would hide it.
+  local stale_any=0 m
+  for m in $manifests; do
+    [ "$(core_tag_in "$m")" = "$VERSION" ] || stale_any=1
+  done
+  if [ "$stale_any" -eq 0 ]; then
+    note "already pinned to $VERSION in every manifest"
+    exit 4
+  fi
+
+  local roots="" touched=0
+  for m in $manifests; do
+    local before
+    before=$(core_tag_in "$m")
+    NEW="$VERSION" perl -i -pe '
+      if (m{git\s*=\s*"https://github\.com/calimero-network/core(?:\.git)?"}
+          && m{tag\s*=\s*"}) {
+        s{(tag\s*=\s*")[^"]*(")}{$1$ENV{NEW}$2};
+      }
+      s{^(\s*min-runtime-version\s*=\s*")[^"]*(")}{$1$ENV{NEW}$2};
+    ' "$m"
+
+    local n
+    n=$(NEW="$VERSION" perl -ne '
+      if (m{git\s*=\s*"https://github\.com/calimero-network/core(?:\.git)?"}
+          && m{tag\s*=\s*"\Q$ENV{NEW}\E"}) { $n++ }
+      END { print $n + 0 }
+    ' "$m")
+    [ "$n" -gt 0 ] || die "${m#$DIR/}: rewrote no dependency lines — not shaped as expected"
+
+    local left
+    left=$(NEW="$VERSION" perl -ne '
+      if (m{git\s*=\s*"https://github\.com/calimero-network/core(?:\.git)?"}
+          && m{tag\s*=\s*"([^"]*)"} && $1 ne $ENV{NEW}) { print "    line $.: $_" }
+    ' "$m")
+    [ -z "$left" ] || die "${m#$DIR/} still pins another core tag after the rewrite:
+$left"
+
+    record_change "${m#$DIR/}"
+    note "${m#$DIR/}: $before -> $VERSION ($n dependency line(s))"
+    touched=$((touched + 1))
+
+    # A lockfile beside the manifest marks a workspace root worth resolving.
+    if [ -f "$(dirname "$m")/Cargo.lock" ]; then roots="$roots $(dirname "$m")"; fi
+  done
+  note "$touched manifest(s) rewritten"
+
+  # The node image has to move with the tag or the scenario boots a merod older
+  # than the runtime the WASM was built for. calimero-studio's own smoke runs
+  # --no-docker against a merod derived from the SDK tag, so the image is a
+  # mirror of the pin there rather than an independent choice — which is exactly
+  # why it must not be left behind.
+  local scen=0 f
+  for f in $(nested_scenario_files); do
+    grep -q 'ghcr\.io/calimero-network/merod:' "$f" || continue
+    NEW="$VERSION" perl -i -pe '
+      s{(ghcr\.io/calimero-network/merod:)[A-Za-z0-9._-]+}{$1$ENV{NEW}}g;
+    ' "$f"
+    record_change "${f#$DIR/}"
+    scen=$((scen + 1))
+  done
+  note "merod image rewritten in $scen scenario file(s)"
+
+  if [ "$NO_LOCK" -eq 1 ]; then
+    note "skipping Cargo.lock refresh (--no-lock)"
+    return 0
+  fi
+
+  command -v cargo >/dev/null 2>&1 || die "cargo is not installed; re-run with --no-lock to edit manifests only"
+
+  # Per workspace root: each has its own lockfile and its own dependency graph.
+  local r
+  for r in $roots; do
+    note "refreshing ${r#$DIR/}/Cargo.lock"
+    ( cd "$r" && cargo update --quiet )
+    record_change "${r#$DIR/}/Cargo.lock"
+  done
 }
 
 bump_cargo_app() {

--- a/.github/scripts/tests/bump-fleet.test.sh
+++ b/.github/scripts/tests/bump-fleet.test.sh
@@ -327,6 +327,88 @@ expect_exit 3 "a package nobody declares is 'not applicable'" \
   bash "$BUMP" --surface npm --pkg @calimero-network/nothing=1.0.0 --dir "$D" --no-lock
 
 # ─────────────────────────────────────────────────────────────────────────────
+echo "nested workspace roots (calimero-studio: neither known path)"
+# ─────────────────────────────────────────────────────────────────────────────
+# Two workspace roots deep in the tree, each with its own lockfile, plus the
+# merod images that have to move with them. Before this shape existed the
+# script exited 3 here — "this does not apply" — and calimero-studio's pin sat
+# twelve releases behind because nothing ever opened a pull request.
+D=$(mkfixture nested)
+mkdir -p "$D/foundation-app/base/logic/crates/service" \
+         "$D/foundation-app/base/test" \
+         "$D/foundation-app/recipes/tally" \
+         "$D/foundation-app/overlays/rooms/test"
+cat > "$D/foundation-app/base/logic/Cargo.toml" <<'EOF'
+[workspace]
+members = ["crates/service"]
+
+[workspace.dependencies]
+calimero-sdk = { git = "https://github.com/calimero-network/core", tag = "0.11.0-rc.1" }
+calimero-storage = { git = "https://github.com/calimero-network/core", tag = "0.11.0-rc.1" }
+EOF
+echo '[[package]]' > "$D/foundation-app/base/logic/Cargo.lock"
+# A MEMBER crate: inherits the pin, carries no git URL. Must not be rewritten,
+# and must not be counted as a root to resolve.
+cat > "$D/foundation-app/base/logic/crates/service/Cargo.toml" <<'EOF'
+[package]
+name = "svc"
+
+[dependencies]
+calimero-sdk = { workspace = true }
+EOF
+cat > "$D/foundation-app/recipes/Cargo.toml" <<'EOF'
+[workspace]
+members = ["tally"]
+
+[workspace.dependencies]
+calimero-sdk = { git = "https://github.com/calimero-network/core", tag = "0.11.0-rc.1" }
+EOF
+echo '[[package]]' > "$D/foundation-app/recipes/Cargo.lock"
+cat > "$D/foundation-app/base/test/smoke.workflow.yml" <<'EOF'
+nodes:
+  image: ghcr.io/calimero-network/merod:0.11.0-rc.1
+EOF
+cat > "$D/foundation-app/overlays/rooms/test/smoke.workflow.yml" <<'EOF'
+nodes:
+  image: ghcr.io/calimero-network/merod:0.11.0-rc.1
+EOF
+commit "$D"
+
+CH="$ROOT/nested-changed.txt"
+expect_exit 0 "bumps every nested root" env CHANGED_FILES_OUT="$CH" \
+  bash "$BUMP" --surface cargo --version 0.11.0-rc.2 --dir "$D" --no-lock
+expect_file "$D/foundation-app/base/logic/Cargo.toml" 'tag = "0.11.0-rc.2"' "  base logic root moved"
+expect_file "$D/foundation-app/recipes/Cargo.toml" 'tag = "0.11.0-rc.2"' "  recipes root moved"
+expect_file "$D/foundation-app/base/test/smoke.workflow.yml" 'merod:0.11.0-rc.2' "  base merod image moved"
+expect_file "$D/foundation-app/overlays/rooms/test/smoke.workflow.yml" 'merod:0.11.0-rc.2' "  overlay merod image moved"
+expect_absent "$D/foundation-app/base/logic/crates/service/Cargo.toml" '0.11.0-rc.2' "  a member crate is left alone"
+expect_file "$CH" 'foundation-app/recipes/Cargo.toml' "  changed-files names the nested manifest"
+expect_absent "$CH" 'crates/service/Cargo.toml' "  ...and not the member crate"
+
+expect_exit 4 "second run is a no-op" \
+  bash "$BUMP" --surface cargo --version 0.11.0-rc.2 --dir "$D" --no-lock
+
+# One root behind the other IS the drift, so it must not read as "already done".
+# Reporting off the first manifest alone would have hidden exactly this.
+( cd "$D" && perl -i -pe 's{0\.11\.0-rc\.2}{0.11.0-rc.1}g' foundation-app/recipes/Cargo.toml \
+    && git -c user.email=t@t -c user.name=t commit -qam skew )
+expect_exit 0 "one root left behind is not 'already pinned'" \
+  bash "$BUMP" --surface cargo --version 0.11.0-rc.2 --dir "$D" --no-lock
+expect_file "$D/foundation-app/recipes/Cargo.toml" 'tag = "0.11.0-rc.2"' "  the straggler moved"
+
+# A tree whose only core pin is at a nested path the script does not know still
+# has to be distinguishable from a tree with no pin at all.
+D=$(mkfixture nested-only-member); mkdir -p "$D/somewhere/deep"
+cat > "$D/somewhere/deep/Cargo.toml" <<'EOF'
+[dependencies]
+calimero-sdk = { git = "https://github.com/calimero-network/core", tag = "0.11.0-rc.1" }
+EOF
+commit "$D"
+expect_exit 0 "an unconventional path is still bumped" \
+  bash "$BUMP" --surface cargo --version 0.11.0-rc.2 --dir "$D" --no-lock
+expect_file "$D/somewhere/deep/Cargo.toml" 'tag = "0.11.0-rc.2"' "  ...and rewritten"
+
+# ─────────────────────────────────────────────────────────────────────────────
 echo "no surface at all"
 # ─────────────────────────────────────────────────────────────────────────────
 D=$(mkfixture bare); echo '{}' > "$D/package.json"; commit "$D"


### PR DESCRIPTION
## The gap

`calimero-studio` consumes core **by git tag** and is not in `fleet.json`, so **no release has ever opened a bump pull request against it**. Its pin sat at `0.11.0-rc.20` while core reached rc.32 — twelve releases — and what eventually noticed was the repo's own weekly cron, five days after rc.32 shipped, in a job most people never look at.

## Listing it is not enough

`bump_cargo` recognised two layouts and studio is neither: there is no root `logic/Cargo.toml`, and no root `Cargo.toml` pinning core. The pins are **workspace roots deeper in the tree**:

| manifest | what it is |
|---|---|
| `foundation-app/base/logic/Cargo.toml` | the scaffold template every generated app is built from |
| `foundation-app/recipes/Cargo.toml` | compiler-checked CRDT idioms the build agent reads |

Adding the `fleet.json` entry on its own would have exited **3** — *"nothing here to bump"* — release after release, and read as success.

## What changed

`cargo` now means one of **three** shapes, still decided by looking rather than by being told:

```
standalone   logic/Cargo.toml                       one contract, its own pins
workspace    Cargo.toml [workspace]                 apps/*/logic, one shared pin
nested       neither, but some Cargo.toml deeper    calimero-studio
             in the tree pins core
```

`nested` finds every `Cargo.toml` in the tree that pins core. Member crates say `calimero-sdk = { workspace = true }` and carry no git URL, so the tag keeps living in exactly one place per workspace; `target/` and `node_modules/` are skipped, because a vendored manifest is not this repository's pin. Each root's own lockfile is resolved separately, and the **merod images in the scenario documents move with the tag** — studio's smoke runs `--no-docker` against a merod derived from the SDK tag, so the image is a mirror of the pin rather than an independent choice.

**Staleness across roots is drift, not a no-op.** Reading *"already pinned"* off the first manifest would have called a tree with one root at rc.32 and another at rc.20 done. The check spans every manifest, and there is a test for exactly that.

## Deliberately left alone

Recorded in `fleet.json` so the next person doesn't "fix" them:

- **studio's merobox pin** — merobox has its own release train, and the compatible pair with a given core is *evidence*, not arithmetic.
- **its cargo-mero `FLOOR_VERSION`** — the oldest release shipping that asset. Settled history, not a mirror of anything.

## Verification

Against a real checkout, not only fixtures. Dry-run over `calimero-studio` at rc.20:

```
cargo (nested): 0.11.0-rc.20 -> 0.11.0-rc.32
  foundation-app/base/logic/Cargo.toml: 0.11.0-rc.20 -> 0.11.0-rc.32 (3 dependency line(s))
  foundation-app/recipes/Cargo.toml: 0.11.0-rc.20 -> 0.11.0-rc.32 (2 dependency line(s))
  2 manifest(s) rewritten
  merod image rewritten in 4 scenario file(s)
```

That set is **byte-identical to the hand-written change in calimero-studio#198**. Both lockfiles refresh to tags `cargo --locked` accepts, a second run exits 4, the two existing shapes still dispatch to their own handlers (`apps` → workspace, `mero-tag` → standalone), and a repo with no pin still exits 3.

Suite: **62 passed, 0 failed** — up from 49.

> One debugging round worth recording, and it is in the commit message: two `[ ... ] && ...` trailing tests. A false test as a loop's last command makes the function exit 1, and under `set -e` that kills the assignment capturing its output — the script died with **no diagnostic at all**, which is the exact failure mode the test suite's header says it exists to prevent. Both are `if` now.

## Note on red bump PRs

The pull request this opens for a source-level break will be **red until someone writes the code**, as it was for `apps#48` at rc.32 (#3807 required every `Mergeable` type to declare how it merges). That is the signal arriving, which is the whole point — the alternative is what happened here: no pull request, and a cron finding out.

Companion: **calimero-studio#198** brings that repo onto rc.32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)