### PR TITLE
test(merod): probe UDP too when picking a swarm port

### DIFF
--- a/crates/merod/tests/watchdog_live.rs
+++ b/crates/merod/tests/watchdog_live.rs
@@ -9,7 +9,7 @@
 //! ignores every stop including `SIGTERM` - which `the_node_stops_on_sigterm` is
 //! here to distinguish from a fault in the watchdogs themselves.
 
-use std::net::TcpListener;
+use std::net::{TcpListener, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -18,6 +18,12 @@ use std::time::{Duration, Instant};
 /// bound a hang, they do not measure latency.
 const READY_TIMEOUT: Duration = Duration::from_secs(120);
 const EXIT_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// How many ports [`free_swarm_port`] draws before giving up. Excluded ranges are
+/// a small slice of the ephemeral range, so a handful of draws clears one with
+/// room to spare; the cap exists so a genuinely unusable environment fails with a
+/// message rather than spinning.
+const SWARM_PORT_PROBES: usize = 32;
 
 /// Kills the node even when an assertion unwinds, and keeps its log so a timeout
 /// can say what the node was doing rather than only that it was doing something.
@@ -61,12 +67,46 @@ fn scratch(tag: &str) -> PathBuf {
 
 /// Asked of the OS rather than hardcoded, so parallel jobs on one runner cannot
 /// collide on a port.
+///
+/// For a TCP-only port, which the server port is. A SWARM port is not TCP-only —
+/// use [`free_swarm_port`], and see the trap documented there.
 fn free_port() -> u16 {
     TcpListener::bind("127.0.0.1:0")
         .expect("bind")
         .local_addr()
         .expect("addr")
         .port()
+}
+
+/// A port free for UDP as well as TCP, which is what a swarm port has to be.
+///
+/// `--swarm-port` becomes TWO listeners rather than one: `init` pushes both
+/// `/tcp/<port>` and `/udp/<port>/quic-v1` (see `cli/init.rs`). A port the OS
+/// hands out for TCP says nothing about its UDP half, and on Windows a UDP bind
+/// inside a Hyper-V / WinNAT *excluded* port range fails with `WSAEACCES` (os
+/// error 10013) although the TCP probe a line earlier succeeded. The node then
+/// dies with `failed to listen on '/ip4/0.0.0.0/udp/<port>/quic-v1'`, and the
+/// test reports only that readiness never arrived — which reads as a broken
+/// watchdog rather than as a port that was never usable. Excluded ranges are
+/// reserved per boot, so it is intermittent and Windows-only.
+///
+/// Probing loopback rather than `0.0.0.0` is deliberate: an exclusion is
+/// system-wide rather than per-interface, so loopback detects it, and it keeps
+/// this probe on the same host the TCP one already uses instead of introducing a
+/// bind that a restrictive sandbox might refuse for unrelated reasons.
+///
+/// This narrows the window; it does not close it. Another process can still take
+/// the port between the probe and the node's own bind — a race the TCP-only
+/// version always had. What it removes is the deterministic case, where the port
+/// could never have worked no matter when it was tried.
+fn free_swarm_port() -> u16 {
+    for _ in 0..SWARM_PORT_PROBES {
+        let port = free_port();
+        if UdpSocket::bind(("127.0.0.1", port)).is_ok() {
+            return port;
+        }
+    }
+    panic!("no port was free for both TCP and UDP after {SWARM_PORT_PROBES} attempts");
 }
 
 /// The node only reaches the select that watches for a stop once every subsystem
@@ -110,7 +150,7 @@ fn init_returning_port(home: &Path, node: &str) -> u16 {
             "--server-port",
             &server_port.to_string(),
             "--swarm-port",
-            &free_port().to_string(),
+            &free_swarm_port().to_string(),
         ])
         .output()
         .expect("run merod init");


### PR DESCRIPTION
## Description

Fixes the intermittent Windows-only `Windows node smoke` failure that took out
#3910 on a commit whose only content was a fleet-script merge. Diagnosed there;
this is the fix, which I deliberately kept out of that PR so as not to widen it.

`watchdog_live`'s `free_port()` asks the OS for a free port by binding a
`TcpListener`, and the result was handed to `--swarm-port`. **That port becomes
two listeners, not one** — `cli/init.rs:507-508`:

```rust
listen.push(format!("{}/tcp/{}", host, self.swarm_port).parse()?);
listen.push(format!("{}/udp/{}/quic-v1", host, self.swarm_port).parse()?);
```

A port the OS hands out for TCP says nothing about its UDP half. On Windows a
UDP bind inside a Hyper-V / WinNAT **excluded port range** fails with
`WSAEACCES` (os error 10013) even though the TCP probe a line earlier succeeded:

```
failed to listen on '/ip4/0.0.0.0/udp/58487/quic-v1'
An attempt was made to access a socket in a way forbidden by its access permissions. (os error 10013)
  at crates\network\src\behaviour.rs:385
```

The node then dies, and the test reports only that readiness never arrived
within 120s — so it reads as a broken watchdog rather than as a port that was
never usable. Excluded ranges are reserved per boot, which is what makes it
intermittent and Windows-only.

## The shape of the fix

`free_swarm_port()` **beside** `free_port()` rather than changing it, because
the two callers want different things. The server port is genuinely TCP-only, so
requiring a UDP-free port there would reject perfectly good ports for no reason.
(The patch I first sketched in #3910 changed `free_port()` itself — that was
cruder, and this is the correction.)

It draws from `free_port()` and keeps drawing until the port is bindable for UDP
too, capped at 32 attempts so a genuinely unusable environment fails with a
message rather than spinning.

Two deliberate choices, both documented at the function:

- **Probes loopback, not `0.0.0.0`.** An exclusion is system-wide rather than
  per-interface, so loopback detects it, and it keeps the probe on the same host
  the TCP one already uses instead of introducing a bind a restrictive sandbox
  might refuse for unrelated reasons.
- **It narrows the window without closing it.** Another process can still take
  the port between the probe and the node's own bind — a race the TCP-only
  version always had. What it removes is the *deterministic* case, where the
  port could never have worked whenever it was tried.

## Scope

One call site, and I verified that rather than assuming it:

- `watchdog_live.rs` is the **only** place in the repo that passes a probed port
  to `--swarm-port` (`grep '"--swarm-port"'` outside `cli/init.rs` returns
  exactly this file), and `--swarm-port` is the only thing that fans one port
  out to both protocols.
- The other port-probing tests — `network/tests/gossipsub_group_topic.rs`,
  `network/tests/rendezvous_namespace.rs` — build `/ip4/127.0.0.1/tcp/{port}`
  listen addrs. TCP-only, so a TCP probe is correct there and they are left
  alone.

## Test plan

```
cargo fmt --check                                        ok
cargo clippy -p merod --all-targets -- -D warnings       ok (exit 0, no warnings)
```

**The failure is not reproducible on Linux, and that is the point** — a TCP-only
probe returns a UDP-free port here every single time, which is exactly why this
hid until a Windows runner drew a poisoned one. So I verified the helper's logic
directly instead, compiled standalone:

```
OK: 200 draws, all TCP+UDP bindable, 199 distinct ports
TCP-only probe returned 39085; UDP bindable = true
```

200 draws, every one terminated inside the cap, and each returned port was then
independently confirmed bindable for both protocols. The second line is the bug
in miniature: on Linux the old probe's port happens to be UDP-free, so nothing
ever checked.

`cargo test -p merod --test watchdog_live -- --include-ignored --test-threads 1`
is running locally as I open this, but those tests are `#[ignore]`d because they
need an environment with netlink permissions, so a failure in my sandbox would
not tell us much either way. **`Windows node smoke` on this PR is the real
confirmation** — it is the job that was failing.

## Proof the fix works

- **Reproduction:** `Windows node smoke` on #3910, run 34543386628 attempt 1 —
  `merod::watchdog_live::the_node_keeps_running_while_its_data_directory_is_intact`
  failed on `/ip4/0.0.0.0/udp/58487/quic-v1`, WSAEACCES. The other two tests in
  the binary passed.
- **Before:** the same check had passed on the previous head of that PR
  (`84865cd4b`) with byte-identical Rust, then failed after a merge commit
  containing no Rust at all — which is what established it as a port draw rather
  than a code change.
- **After:** re-running that job on the identical commit passed, confirming the
  draw-dependent diagnosis. This PR removes the dependence on the draw.

Honest limit: a passing Windows job here is consistent with the fix but cannot
*prove* it, since the pre-fix code also passed most draws. What the change buys
is that a poisoned port is now skipped instead of failing the run.

## Wire contract (SDK gate)

Not applicable — test-only change, no DTO, no route, no wire format.

- [ ] Regenerated wire fixtures — n/a
- [ ] Updated `crates/server/endpoints.json` — n/a
- [ ] Linked the matching mero-js PR — n/a

## Documentation update

None needed beyond the code: the trap is documented at `free_swarm_port()`
itself, which is where someone adding another live test will be standing, and
`free_port()`'s own doc now points at it so the TCP-only/both distinction is
visible from either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_