### PR TITLE
fix(tee-attestation): record which TCB baseline decided the verdict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,6 +1739,7 @@ dependencies = [
  "eyre",
  "hex",
  "reqwest 0.12.28",
+ "serde_json",
  "tdx-quote",
  "tdx_workload_attestation",
  "tracing",

--- a/crates/tee-attestation/Cargo.toml
+++ b/crates/tee-attestation/Cargo.toml
@@ -19,6 +19,9 @@ eyre.workspace = true
 hex.workspace = true
 tracing.workspace = true
 base64.workspace = true
+# Reads `tcbEvaluationDataNumber` out of fetched collateral so a TCB verdict
+# records which baseline produced it. See `verify::tcb_evaluation_data_number_of`.
+serde_json.workspace = true
 
 # Quote verification dependencies (cross-platform)
 dcap-qvl.workspace = true

--- a/crates/tee-attestation/src/policy.rs
+++ b/crates/tee-attestation/src/policy.rs
@@ -424,6 +424,7 @@ mod tests {
             application_hash_verified: true,
             tcb_status: Some(tcb_status.to_owned()),
             advisory_ids: Vec::new(),
+            tcb_evaluation_data_number: None,
             quote,
         }
     }

--- a/crates/tee-attestation/src/verify.rs
+++ b/crates/tee-attestation/src/verify.rs
@@ -2,11 +2,10 @@
 
 use calimero_server_primitives::admin::Quote;
 use dcap_qvl::collateral::{CollateralClient, INTEL_PCS_URL};
+use dcap_qvl::tcb_info::TcbInfo as DcapTcbInfo;
 use dcap_qvl::verify::verify;
 use tdx_quote::Quote as TdxQuote;
-#[cfg(feature = "mock-attestation")]
-use tracing::warn;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::error::AttestationError;
 #[cfg(feature = "mock-attestation")]
@@ -38,6 +37,31 @@ pub struct VerificationResult {
     ///
     /// NOT consulted by [`Self::is_valid`]; provided for caller-side policy.
     pub advisory_ids: Vec<String>,
+    /// Intel's `tcbEvaluationDataNumber` for the collateral this verdict was
+    /// computed against — i.e. *which* baseline decided `tcb_status`.
+    ///
+    /// `tcb_status` is meaningless without it. `OutOfDate` does not say "this
+    /// host is unpatched"; it says "this host is behind whichever TCB
+    /// evaluation data the verifier happened to fetch". Intel publishes at
+    /// least two concurrently (`update=early` runs ahead of `update=standard`),
+    /// so two verifiers appraising the *same* host at the *same* moment can
+    /// legitimately disagree.
+    ///
+    /// That matters here because a node is judged twice by different code:
+    /// this crate (dcap-qvl against Intel PCS) decides admission, and the
+    /// mero-tee KMS (Intel Trust Authority) decides key release. The invariant
+    /// those two must preserve is `policy_core ⊆ policy_kms` — anything core
+    /// admits, the KMS must be willing to serve a key to. Neither side pins its
+    /// baseline, so the invariant currently holds only because the KMS
+    /// allowlist is the wider of the two. Tighten the KMS to `UpToDate` alone
+    /// while core is evaluating against older collateral and the failure is a
+    /// node that joins its group and then silently never receives a key.
+    ///
+    /// Recorded so that divergence is visible in logs and to callers rather
+    /// than inferred from a stuck node. `None` when collateral was not fetched
+    /// (mock quotes) or the TCB info could not be parsed — it is diagnostic,
+    /// never a gate.
+    pub tcb_evaluation_data_number: Option<u32>,
     /// The parsed quote structure.
     ///
     /// Its `body` carries the measurement registers (`mrtd` / `rtmr0..3` /
@@ -93,6 +117,26 @@ impl VerificationResult {
     ///   key-release side (external consumer of this crate).
     pub fn is_valid(&self) -> bool {
         self.quote_verified && self.nonce_verified && self.application_hash_verified
+    }
+}
+
+/// Read Intel's `tcbEvaluationDataNumber` out of fetched collateral.
+///
+/// Parses the same string dcap-qvl itself deserializes: the collateral carries
+/// the *unwrapped* `tcbInfo` object, not the signed `{tcbInfo, signature}`
+/// envelope the PCS returns, so this decodes straight into [`DcapTcbInfo`].
+///
+/// Diagnostic only. A parse failure degrades to `None` and is logged rather
+/// than surfaced as an error: the number qualifies a verdict, it never gates
+/// one, and failing an otherwise-good attestation over an unreadable
+/// diagnostic would trade a real security check for a cosmetic one.
+fn tcb_evaluation_data_number_of(tcb_info_json: &str) -> Option<u32> {
+    match serde_json::from_str::<DcapTcbInfo>(tcb_info_json) {
+        Ok(info) => Some(info.tcb_evaluation_data_number),
+        Err(err) => {
+            warn!(error=?err, "Could not read tcbEvaluationDataNumber from collateral");
+            None
+        }
     }
 }
 
@@ -166,6 +210,8 @@ pub async fn verify_attestation(
         })?
         .as_secs();
 
+    let tcb_evaluation_data_number = tcb_evaluation_data_number_of(&collateral.tcb_info);
+
     let (quote_verified, tcb_status, advisory_ids) = match verify(quote_bytes, &collateral, now) {
         Ok(verified_report) => {
             info!("Quote cryptographic verification: PASSED");
@@ -223,8 +269,17 @@ pub async fn verify_attestation(
         application_hash_verified,
         tcb_status,
         advisory_ids,
+        tcb_evaluation_data_number,
         quote,
     };
+
+    // Logged next to the status it qualifies: a bare `OutOfDate` in a log is
+    // not actionable without knowing which baseline produced it.
+    info!(
+        tcb_status = ?result.tcb_status,
+        tcb_evaluation_data_number = ?result.tcb_evaluation_data_number,
+        "TCB verdict and the collateral baseline it was measured against"
+    );
 
     if result.is_valid() {
         info!("Overall verification: PASSED");
@@ -319,6 +374,8 @@ pub fn verify_mock_attestation(
         application_hash_verified,
         tcb_status: Some("Mock".to_owned()),
         advisory_ids: Vec::new(),
+        // No collateral is fetched for a mock quote, so there is no baseline.
+        tcb_evaluation_data_number: None,
         quote,
     };
 
@@ -329,4 +386,68 @@ pub fn verify_mock_attestation(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tcb_evaluation_data_number_of;
+
+    /// Shaped like the `tcbInfo` object Intel's PCS returns (and like what
+    /// dcap-qvl stores after unwrapping the signed envelope), trimmed to the
+    /// fields `TcbInfo` requires. The number is the one Intel began serving to
+    /// `update=early` callers on 2026-08-11, and the one Intel Trust Authority
+    /// reported for a Calimero node on 2026-09-11.
+    fn tcb_info_json(evaluation_data_number: u32) -> String {
+        format!(
+            r#"{{
+              "id": "TDX",
+              "version": 3,
+              "issueDate": "2026-08-11T00:00:00Z",
+              "nextUpdate": "2026-09-10T00:00:00Z",
+              "fmspc": "B0C06F000000",
+              "pceId": "0000",
+              "tcbType": 0,
+              "tcbEvaluationDataNumber": {evaluation_data_number},
+              "tcbLevels": []
+            }}"#
+        )
+    }
+
+    #[test]
+    fn reads_the_evaluation_data_number_from_collateral() {
+        assert_eq!(tcb_evaluation_data_number_of(&tcb_info_json(22)), Some(22));
+    }
+
+    /// The whole point of recording it: `early` (22) and `standard` (20) are
+    /// live at the same time, so the number is what distinguishes two verifiers
+    /// that disagree about one host from two that were asked different
+    /// questions.
+    #[test]
+    fn distinguishes_the_early_and_standard_baselines() {
+        let early = tcb_evaluation_data_number_of(&tcb_info_json(22));
+        let standard = tcb_evaluation_data_number_of(&tcb_info_json(20));
+
+        assert_eq!(early, Some(22));
+        assert_eq!(standard, Some(20));
+        assert_ne!(early, standard);
+    }
+
+    /// Diagnostic, never a gate: unreadable collateral must not fail an
+    /// otherwise-good attestation.
+    #[test]
+    fn unparseable_collateral_degrades_to_none() {
+        assert_eq!(tcb_evaluation_data_number_of("not json"), None);
+        assert_eq!(tcb_evaluation_data_number_of("{}"), None);
+        assert_eq!(tcb_evaluation_data_number_of(""), None);
+    }
+
+    /// Guards the envelope-vs-inner-object distinction. dcap-qvl stores the
+    /// unwrapped `tcbInfo`; if a future version stored the signed envelope
+    /// instead, this parse would silently start returning `None` and the
+    /// divergence signal would go quiet without anything failing.
+    #[test]
+    fn does_not_accept_the_signed_envelope() {
+        let envelope = format!(r#"{{"tcbInfo": {}, "signature": "ab"}}"#, tcb_info_json(22));
+        assert_eq!(tcb_evaluation_data_number_of(&envelope), None);
+    }
 }


### PR DESCRIPTION
# [tee-attestation] record which TCB baseline decided the verdict

## Description

`tcb_status` on its own is not interpretable. `OutOfDate` does **not** mean "this host is unpatched" — it means "this host is behind whichever TCB evaluation data the verifier happened to fetch." Intel publishes at least two concurrently: `update=early` runs ahead of `update=standard`. So two verifiers appraising the *same host* at the *same moment* can legitimately disagree, and nothing in a log tells you which happened.

That is not hypothetical for us. A node is judged twice, by different code:

| verifier | who runs it | what it decides |
| --- | --- | --- |
| this crate — `dcap-qvl` against Intel PCS | core | group **admission** |
| Intel Trust Authority | the mero-tee KMS | **key release** |

On 2026-09-11 ITA reported `tcbEvaluationDataNumber = 22` for a Calimero node — the `early` collateral, which Intel began serving on 2026-08-11. This crate requests neither `update` nor `tcbEvaluationDataNumber` (`verify.rs`: `CollateralClient::with_default_http(INTEL_PCS_URL)` then a bare `fetch`), so it takes whatever the PCS default yields. Nothing pins the two together, and neither side records which baseline it used.

**Why that matters.** The invariant these two must preserve is `policy_core ⊆ policy_kms` — anything core admits, the KMS must be willing to serve a key to. Today it holds only because the KMS allowlist (`["uptodate", "outofdate"]`) is the wider of the two. Tighten the KMS to `UpToDate` alone — which is the stated goal, with the exit condition already written down at `DEFAULT_ALLOWED_TCB_STATUS` — while core is evaluating against older collateral, and the failure mode is **a node that joins its group and then silently never receives a key.** No error names the cause.

This PR makes the divergence visible. It deliberately does **not** resolve it — see Scope below.

### Changes

- `VerificationResult` gains `tcb_evaluation_data_number: Option<u32>`, parsed from the fetched collateral and documented with the invariant above. This fits the type's existing contract, which already states it is a *report* carrying "the raw material a caller needs to make a policy decision," not a verdict.
- Logged beside the status it qualifies — a bare `OutOfDate` in a log is not actionable without it.
- `None` for mock quotes (no collateral is fetched) and for unparseable TCB info.
- New dep `serde_json` on this crate. It was already in the workspace lock, so no new package enters the dependency graph — `Cargo.lock` gains one line, a back-reference.

### Scope — what this deliberately does not do

Pinning an explicit baseline (`update=early` to match ITA, or `standard`) is the other half. I'm not doing it here because:

- It changes **which collateral is fetched**, which changes **admission decisions**.
- `dcap-qvl` 0.5.3 hardcodes `qe/identity?update=standard` but sends `tcb?fmspc=…` with no `update` at all, so pinning means supplying a custom `HttpClient` — a real change to the verification path.
- I cannot validate it against the live Intel PCS from a sandboxed environment. Shipping an unvalidated change to attestation collateral fetching is how you brick joins fleet-wide.

It belongs in its own change, argued on the evidence this one makes available.

## Test plan

`cargo test -p calimero-tee-attestation --lib` — 24 pass, including four new:

| test | pins |
| --- | --- |
| `reads_the_evaluation_data_number_from_collateral` | the number is parsed from real-shaped PCS `tcbInfo` |
| `distinguishes_the_early_and_standard_baselines` | 22 vs 20 are distinguishable — the entire point |
| `unparseable_collateral_degrades_to_none` | diagnostic, never a gate: bad JSON must not fail a good attestation |
| `does_not_accept_the_signed_envelope` | guards the envelope-vs-inner-object distinction |

That last one is the non-obvious one. `dcap-qvl` stores the **unwrapped** `tcbInfo` object, not the signed `{tcbInfo, signature}` envelope the PCS returns (its own `verify.rs:300` deserializes the same string). If a future version stored the envelope instead, this parse would silently start returning `None` and the divergence signal would go quiet **without anything failing**. The test fails loudly instead.

Full gate, run via `./scripts/check-like-ci.py --list` rather than from memory:

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean, exit 0
- `cargo clippy -p merod -p calimero-node -p calimero-server -p calimero-tee-attestation --all-targets --features mock-attestation -- -D warnings` — clean, exit 0
- `cargo test -p calimero-tee-attestation --features mock-attestation` — 24 pass
- `cargo test -p merod --features mock-attestation` — 105 + 2 pass

Two disclosures rather than silent gaps:

- The two build scripts that fetch `auth-frontend` / `webui` over HTTPS fail TLS in this sandbox. I ran the gate with `CALIMERO_AUTH_FRONTEND_SRC` / `CALIMERO_WEBUI_SRC` pointed at empty local dirs — the documented escape hatch — rather than narrowing what I ran. No TLS verification was disabled.
- `cargo deny check licenses sources` was **not** run: cargo-deny isn't installed here. The argument that it's a no-op is that `serde_json` is an existing workspace dependency and `Cargo.lock` gains only a back-reference, no new package — but that is reasoning, not a run. Worth confirming in CI.

## Proof the fix works

This is not a bug fix with a failing reproduction — it adds a signal that did not exist. The "before" is that `tcb_status` was logged with no way to tell which baseline produced it; the "after" is the new `info!` line carrying both, and `does_not_accept_the_signed_envelope` is the regression test that keeps the signal from going quiet.

The motivating observation is real and external: ITA reported `tcbEvaluationDataNumber = 22`, `attester_tcb_status = OutOfDate`, advisories `INTEL-SA-01439` / `INTEL-SA-01442`, `attester_tcb_date = 2026-02-11` for a released Calimero node image on 2026-09-11.

## Wire contract (SDK gate)

No HTTP wire DTO or route changes. `VerificationResult` is an internal Rust type, not a serialized DTO.

- [ ] Regenerated wire fixtures — n/a, no DTO changed
- [ ] Updated `crates/server/endpoints.json` — n/a, no routes changed
- [ ] Linked the matching mero-js PR — n/a

## Documentation update

The field carries its rationale in a doc comment, which is where a caller deciding policy will meet it. If the follow-up pins a baseline, that decision belongs in the protocol docs alongside the existing `DEFAULT_ALLOWED_TCB_STATUS` reasoning — this PR doesn't make that choice, so there's nothing to state yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_